### PR TITLE
Added CLI option to change metadata file type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,5 @@ fabric.properties
 # Project specific
 /temp/
 /projects/
+
+.idea/

--- a/marimba/core/schemas/base.py
+++ b/marimba/core/schemas/base.py
@@ -8,7 +8,9 @@ The BaseMetadata class provides a standard interface that all metadata implement
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Optional
+
+from marimba.core.utils.metadata_saver import yaml_saver
 
 
 class BaseMetadata(ABC):
@@ -79,6 +81,7 @@ class BaseMetadata(ABC):
         items: dict[str, list["BaseMetadata"]],
         *,
         dry_run: bool = False,
+        saver_overwrite: Optional[Callable[[Path, str, dict[str, Any]], None]] = None,
     ) -> None:
         """Create dataset-level metadata from a collection of items."""
         raise NotImplementedError

--- a/marimba/core/schemas/ifdo.py
+++ b/marimba/core/schemas/ifdo.py
@@ -23,11 +23,11 @@ Classes:
 
 import io
 import json
+import uuid
 from datetime import datetime, timezone
 from fractions import Fraction
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
-from uuid import uuid4
+from typing import TYPE_CHECKING, Any, cast, Callable, Optional
 
 import piexif
 from PIL import Image
@@ -35,6 +35,7 @@ from rich.progress import Progress, SpinnerColumn, TaskID
 
 from marimba.core.schemas.base import BaseMetadata
 from marimba.core.utils.log import get_logger
+from marimba.core.utils.metadata_saver import yaml_saver
 from marimba.core.utils.rich import get_default_columns
 from marimba.lib import image
 from marimba.lib.decorators import multithreaded
@@ -54,7 +55,7 @@ class iFDOMetadata(BaseMetadata):  # noqa: N801
     iFDO metadata implementation that adapts ImageData to the BaseMetadata interface.
     """
 
-    DEFAULT_METADATA_NAME = "ifdo.yml"
+    DEFAULT_METADATA_NAME = "ifdo"
 
     def __init__(
         self,
@@ -149,32 +150,36 @@ class iFDOMetadata(BaseMetadata):  # noqa: N801
         metadata_name: str | None = None,
         *,
         dry_run: bool = False,
+        saver_overwrite: Optional[Callable[[Path, str, dict[str, Any]], None]] = None,
     ) -> None:
         """Create an iFDO from the metadata items."""
+
+        saver = yaml_saver if saver_overwrite is None else saver_overwrite
+
+        # Convert BaseMetadata items to ImageData for iFDO
+        image_set_items = {
+            path: [item.image_data for item in metadata_items if isinstance(item, iFDOMetadata)]
+            for path, metadata_items in items.items()
+        }
+
+        ifdo = iFDO(
+            image_set_header=ImageSetHeader(
+                image_set_name=dataset_name,
+                image_set_uuid=str(uuid.uuid4()),
+                image_set_handle="",  # TODO @<cjackett>: Populate from distribution target URL
+            ),
+            image_set_items=image_set_items,
+        )
+
+        # If no metadata_name provided, use default
+        if not metadata_name:
+            output_name = cls.DEFAULT_METADATA_NAME
+        # If metadata_name is provided but missing extension, add it
+        else:
+            output_name = metadata_name if metadata_name.endswith(".ifdo") else f"{metadata_name}.ifdo"
+
         if not dry_run:
-            # Convert BaseMetadata items to ImageData for iFDO
-            image_set_items = {
-                path: [item.image_data for item in metadata_items if isinstance(item, iFDOMetadata)]
-                for path, metadata_items in items.items()
-            }
-
-            ifdo = iFDO(
-                image_set_header=ImageSetHeader(
-                    image_set_name=dataset_name,
-                    image_set_uuid=str(uuid4()),
-                    image_set_handle="",  # TODO @<cjackett>: Populate from distribution target URL
-                ),
-                image_set_items=image_set_items,
-            )
-
-            # If no metadata_name provided, use default
-            if not metadata_name:
-                output_name = cls.DEFAULT_METADATA_NAME
-            # If metadata_name is provided but missing extension, add it
-            else:
-                output_name = metadata_name if metadata_name.endswith(".ifdo.yml") else f"{metadata_name}.ifdo.yml"
-
-            ifdo.save(root_dir / output_name)
+            saver(root_dir, output_name, ifdo.to_dict())
 
     @classmethod
     def process_files(

--- a/marimba/core/utils/metadata_saver.py
+++ b/marimba/core/utils/metadata_saver.py
@@ -1,0 +1,30 @@
+import json
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+
+class MetadataSaverTypes(str, Enum):
+    json = "json"
+    yaml = "yaml"
+
+
+def json_saver(path: Path, file_name: str, data: dict[str, Any]) -> None:
+    with open(path / f"{file_name}.json", "w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2)
+
+
+def yaml_saver(path: Path, file_name: str, data: dict[str, Any]) -> None:
+    with open(path / f"{file_name}.yaml", "w", encoding="utf-8") as file:
+        yaml.safe_dump(data, file)
+
+
+def get_saver(saver_name: MetadataSaverTypes) -> Callable:
+    match saver_name:
+        case MetadataSaverTypes.json:
+            return json_saver
+        case MetadataSaverTypes.yaml:
+            return yaml_saver
+        case _:
+            raise ValueError(f"Unknown saver: {saver_name}")

--- a/marimba/core/wrappers/dataset.py
+++ b/marimba/core/wrappers/dataset.py
@@ -42,7 +42,7 @@ from collections.abc import Iterable
 from math import isnan
 from pathlib import Path
 from shutil import copy2, copytree, ignore_patterns
-from typing import Any
+from typing import Any, Optional, Callable
 
 from rich.progress import Progress, SpinnerColumn, TaskID
 
@@ -86,6 +86,7 @@ class DatasetWrapper(LogMixin):
         contact_email: str | None = None,
         *,
         dry_run: bool = False,
+        metadata_saver_overwrite: Optional[Callable[[Path, str, dict[str, Any]], None]] = None,
     ) -> None:
         """
         Initialize a new instance of the class.
@@ -100,6 +101,7 @@ class DatasetWrapper(LogMixin):
             contact_name (Optional[str]): The name of the contact person. Defaults to None.
             contact_email (Optional[str]): The email address of the contact person. Defaults to None.
             dry_run (bool): If True, the method runs in dry-run mode without making any changes. Defaults to False.
+            metadata_saver_overwrite (Optional[Callable[[Path, str, dict[str, Any]], None]]): Saving function overwriting the default metadata saving function. Defaults to None.
         """
         self._root_dir = Path(root_dir)
         self._project_dir = self._root_dir.parent.parent
@@ -108,6 +110,7 @@ class DatasetWrapper(LogMixin):
         self._contact_email = contact_email
         self._dry_run = dry_run
         self._summary_name = "summary.md"
+        self._metadata_saver_overwrite = metadata_saver_overwrite
 
         if not dry_run:
             self._check_file_structure()
@@ -255,6 +258,7 @@ class DatasetWrapper(LogMixin):
         contact_email: str | None = None,
         *,
         dry_run: bool = False,
+        metadata_saver: Optional[Callable[[Path, str, dict[str, Any]], None]] = None,
     ) -> "DatasetWrapper":
         """
         Create a new dataset.
@@ -288,7 +292,7 @@ class DatasetWrapper(LogMixin):
             logs_dir.mkdir()
             pipeline_logs_dir.mkdir()
 
-        return cls(root_dir, version=version, contact_name=contact_name, contact_email=contact_email, dry_run=dry_run)
+        return cls(root_dir, version=version, contact_name=contact_name, contact_email=contact_email, dry_run=dry_run, metadata_saver_overwrite=metadata_saver)
 
     def _check_file_structure(self) -> None:
         """
@@ -609,6 +613,7 @@ class DatasetWrapper(LogMixin):
                 root_dir=self.root_dir,
                 items=type_items,
                 dry_run=self.dry_run,
+                saver=self._metadata_saver_overwrite
             )
 
     def _log_metadata_summary(

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -39,7 +39,7 @@ import math
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional, Callable
 
 from rich.progress import Progress, SpinnerColumn
 
@@ -1078,6 +1078,7 @@ class ProjectWrapper(LogMixin):
         contact_email: str | None = None,
         zoom: int | None = None,
         max_workers: int | None = None,
+        metadata_saver_overwrite: Optional[Callable[[Path, str, dict[str, Any]], None]] = None
     ) -> DatasetWrapper:
         """
         Create a Marimba dataset from a dataset mapping.
@@ -1091,6 +1092,7 @@ class ProjectWrapper(LogMixin):
             contact_email: The email of the contact person for the dataset. Defaults to None.
             zoom: The zoom level for the dataset. Defaults to None.
             max_workers: The maximum number of worker processes to use. If None, uses all available CPU cores.
+            metadata_saver_overwrite (Optional[Callable[[Path, str, dict[str, Any]], None]]): Saving function overwriting the default metadata saving function. Defaults to None.
 
         Returns:
             A DatasetWrapper instance representing the created dataset.
@@ -1112,6 +1114,7 @@ class ProjectWrapper(LogMixin):
             contact_name=contact_name,
             contact_email=contact_email,
             dry_run=self.dry_run,
+            metadata_saver=metadata_saver_overwrite
         )
 
         # Populate it

--- a/marimba/main.py
+++ b/marimba/main.py
@@ -45,6 +45,7 @@ from marimba.core.distribution.base import DistributionTargetBase
 from marimba.core.utils.constants import PROJECT_DIR_HELP, Operation
 from marimba.core.utils.log import LogLevel, get_logger, get_rich_handler
 from marimba.core.utils.map import NetworkConnectionError
+from marimba.core.utils.metadata_saver import MetadataSaverTypes, get_saver
 from marimba.core.utils.paths import find_project_dir_or_exit
 from marimba.core.utils.rich import error_panel, format_entity, success_panel
 from marimba.core.wrappers.dataset import DatasetWrapper
@@ -219,6 +220,7 @@ def package_command(
         None,
         help="Maximum number of worker processes to use. If None, uses all available CPU cores.",
     ),
+    metadata_output: MetadataSaverTypes | None = typer.Option(None, help="Output metadata format"),
 ) -> None:
     """
     Package up a Marimba collection ready for distribution.
@@ -231,6 +233,8 @@ def package_command(
     # If no collection and pipeline names are specified, package all collections and pipelines
     collection_names = collection_name if collection_name else list(project_wrapper.collection_wrappers.keys())
     pipeline_names = pipeline_name if pipeline_name else list(project_wrapper.pipeline_wrappers.keys())
+
+    metadata_saver_overwrite = None if metadata_output is None else get_saver(metadata_output)
 
     try:
         # Compose the dataset
@@ -252,6 +256,7 @@ def package_command(
             contact_email=contact_email,
             zoom=zoom,
             max_workers=max_workers,
+            metadata_saver_overwrite=metadata_saver_overwrite,
         )
 
         elapsed_time = time.time() - start_time

--- a/tests/core/schemas/test_ifdo.py
+++ b/tests/core/schemas/test_ifdo.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ifdo.models import ImageData
+
+from marimba.core.schemas.ifdo import iFDOMetadata
+
+
+def test_create_dataset_metadata():
+    mock_uuid = "a43a84f2-b657-44e0-bafe-72e2624115fa"
+
+    def mock_saver(path: Path, output_name: str, data: dict[str, Any]) -> None:
+        assert path.name == "tmp"
+        assert output_name == "ifdo"
+        assert data == {
+            "image-set-header": {
+                "image-set-name": "TestDataSet",
+                "image-set-uuid": mock_uuid,
+                "image-set-handle": "",
+                'image-set-ifdo-version': 'v2.1.0'
+            },
+            "image-set-items": {
+                "image.jpg": [
+                    {
+                        "image-altitude-meters": 0.0
+                    }
+                ]
+            }
+        }
+
+    data_setname = "TestDataSet"
+    root_dir = Path("/tmp")
+    items = {"image.jpg":
+        [
+            iFDOMetadata(
+                image_data=ImageData(image_altitude_meters=0.0)
+            )
+        ]
+    }
+    with patch('uuid.uuid4', MagicMock(return_value=mock_uuid)):
+        iFDOMetadata.create_dataset_metadata(data_setname, root_dir, items, saver_overwrite=mock_saver)
+


### PR DESCRIPTION
Added the optional  CLI option `--metadata-output [yaml|json]` for the command `marimba package` to overwrite the default metadata file type specified by the implementations of the `BaseMetadata` class. To achieve this, a "metadata saving" function is injected into `BaseMetadata.create_dataset_metadata` function which overwrites the default "metadata saving" function. The saving functions have the following signature:

```py
def saver(path: Path, file_name: str, data: dict[str, Any]) -> None:
    ...
```

This feature addition should not break the behavior of marimba.