### PR TITLE
Fixed missing logging import

### DIFF
--- a/marimba/core/schemas/ifdo.py
+++ b/marimba/core/schemas/ifdo.py
@@ -23,6 +23,7 @@ Classes:
 
 import io
 import json
+import logging
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone


### PR DESCRIPTION
This PR adds a missing import which currently prevents marimba from running at all.