### PR TITLE
Added CLI Option to change the metdata generation level

### DIFF
--- a/marimba/core/schemas/base.py
+++ b/marimba/core/schemas/base.py
@@ -79,6 +79,7 @@ class BaseMetadata(ABC):
         dataset_name: str,
         root_dir: Path,
         items: dict[str, list["BaseMetadata"]],
+        metadata_name: str | None = None,
         *,
         dry_run: bool = False,
         saver_overwrite: Callable[[Path, str, dict[str, Any]], None] | None = None,

--- a/marimba/core/schemas/generic.py
+++ b/marimba/core/schemas/generic.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Union, cast
 
 from marimba.core.schemas.base import BaseMetadata
-from marimba.core.utils.metadata import json_saver
+from marimba.core.utils.metadata import yaml_saver
 
 
 class GenericMetadata(BaseMetadata):
@@ -182,8 +182,8 @@ class GenericMetadata(BaseMetadata):
         dry_run: bool = False,
         saver_overwrite: Callable[[Path, str, dict[str, Any]], None] | None = None,
     ) -> None:
-        """Create dataset-level metadata by combining all items into a JSON file."""
-        saver = json_saver if saver_overwrite is None else saver_overwrite
+        """Create dataset-level metadata by combining all items into a YAML file."""
+        saver = yaml_saver if saver_overwrite is None else saver_overwrite
 
         dataset_metadata = {
             "dataset_name": dataset_name,

--- a/marimba/core/schemas/generic.py
+++ b/marimba/core/schemas/generic.py
@@ -6,6 +6,7 @@ metadata about files. It handles basic metadata attributes like datetime, geoloc
 without the complexity of specialized metadata schemas.
 """
 
+import logging
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path

--- a/marimba/core/schemas/ifdo.py
+++ b/marimba/core/schemas/ifdo.py
@@ -23,6 +23,7 @@ Classes:
 
 import io
 import json
+import logging
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone

--- a/marimba/core/utils/constants.py
+++ b/marimba/core/utils/constants.py
@@ -33,3 +33,18 @@ class Operation(str, Enum):
     copy = "copy"
     move = "move"
     link = "link"
+
+
+class MetadataGenerationLevelOptions(str, Enum):
+    """
+    Defines an enumeration of metadata generation levels options.
+
+    Attributes:
+        - project: One metadata file is generated for a project.
+        - pipeline: One metadata file is generated per pipeline.
+        - collection: One metadata file is generated per pipeline and per collection.
+    """
+
+    project = "project"
+    pipeline = "pipeline"
+    collection = "collection"

--- a/marimba/core/utils/dataset.py
+++ b/marimba/core/utils/dataset.py
@@ -1,0 +1,90 @@
+"""
+Dataset mapping processors decorators.
+
+This module provides decorators for applying dataset mapping processors at different project levels. It also provides a
+factory function for retrieving a decorator based on the MetadataGenerationLevelOptions enum.
+"""
+
+from collections.abc import Callable
+from functools import reduce
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from marimba.core.schemas.base import BaseMetadata
+from marimba.core.utils.constants import MetadataGenerationLevelOptions
+
+PIPELINE_DATASET_MAPPING_TYPE: TypeAlias = dict[
+    str,
+    dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]],
+]
+DATASET_MAPPING_TYPE: TypeAlias = dict[str, PIPELINE_DATASET_MAPPING_TYPE]
+
+MAPPING_PROCESSOR_TYPE: TypeAlias = Callable[[PIPELINE_DATASET_MAPPING_TYPE, str | None], dict[str, list[BaseMetadata]]]
+DECORATOR_TYPE: TypeAlias = Callable[[MAPPING_PROCESSOR_TYPE, DATASET_MAPPING_TYPE], dict[str, list[BaseMetadata]]]
+
+
+def get_mapping_processor_decorator(
+    level: MetadataGenerationLevelOptions,
+) -> DECORATOR_TYPE:
+    """
+    Returns a decorator that applies a mapping processor to the given level.
+
+    Args:
+        level: Metadata generation level.
+
+    Returns:
+        Decorator for a mapping processor.
+    """
+    if level == MetadataGenerationLevelOptions.project:
+        return _run_mapping_processor
+    if level == MetadataGenerationLevelOptions.pipeline:
+        return _run_mapping_processor_per_pipeline
+    if level == MetadataGenerationLevelOptions.collection:
+        return _run_mapping_processor_per_pipline_and_collection
+
+    raise TypeError(f"Unknown mapping processor type: {level}")
+
+
+def _run_mapping_processor(
+    dataset_mapping_processor: MAPPING_PROCESSOR_TYPE,
+    dataset_mapping: DATASET_MAPPING_TYPE,
+) -> dict[str, list[BaseMetadata]]:
+    pipeline_dataset_mapping = _reduce_dataset_mapping(dataset_mapping)
+    return dataset_mapping_processor(pipeline_dataset_mapping, None)
+
+
+def _reduce_dataset_mapping(dataset_mapping: DATASET_MAPPING_TYPE) -> PIPELINE_DATASET_MAPPING_TYPE:
+    return {
+        pipeline_name: reduce(lambda x, y: x | y, pipeline_data.values(), {})
+        for pipeline_name, pipeline_data in dataset_mapping.items()
+    }
+
+
+def _run_mapping_processor_per_pipeline(
+    dataset_mapping_processor: MAPPING_PROCESSOR_TYPE,
+    dataset_mapping: DATASET_MAPPING_TYPE,
+) -> dict[str, list[BaseMetadata]]:
+    dataset_items: dict[str, list[BaseMetadata]] = {}
+    for pipeline_name, pipeline_data in dataset_mapping.items():
+        pipeline_mapping = _reduce_dataset_mapping({pipeline_name: pipeline_data})
+        collection_dataset_items = dataset_mapping_processor(pipeline_mapping, f"{pipeline_name}")
+        dataset_items = dataset_items | collection_dataset_items
+
+    return dataset_items
+
+
+def _run_mapping_processor_per_pipline_and_collection(
+    dataset_mapping_processor: MAPPING_PROCESSOR_TYPE,
+    dataset_mapping: DATASET_MAPPING_TYPE,
+) -> dict[str, list[BaseMetadata]]:
+    dataset_items: dict[str, list[BaseMetadata]] = {}
+    for pipeline_name, pipeline_mapping in dataset_mapping.items():
+        for collection_name, collection_data in pipeline_mapping.items():
+            collection_mapping = {pipeline_name: collection_data}
+            collection_dataset_items = dataset_mapping_processor(
+                collection_mapping,
+                f"{collection_name}.{pipeline_name}",
+            )
+            dataset_items = dataset_items | collection_dataset_items
+
+    return dataset_items

--- a/marimba/core/utils/dataset.py
+++ b/marimba/core/utils/dataset.py
@@ -8,7 +8,7 @@ factory function for retrieving a decorator based on the MetadataGenerationLevel
 from collections.abc import Callable
 from functools import reduce
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, TypeVar
 
 from marimba.core.schemas.base import BaseMetadata
 from marimba.core.utils.constants import MetadataGenerationLevelOptions
@@ -19,8 +19,40 @@ PIPELINE_DATASET_MAPPING_TYPE: TypeAlias = dict[
 ]
 DATASET_MAPPING_TYPE: TypeAlias = dict[str, PIPELINE_DATASET_MAPPING_TYPE]
 
-MAPPING_PROCESSOR_TYPE: TypeAlias = Callable[[PIPELINE_DATASET_MAPPING_TYPE, str | None], dict[str, list[BaseMetadata]]]
-DECORATOR_TYPE: TypeAlias = Callable[[MAPPING_PROCESSOR_TYPE, DATASET_MAPPING_TYPE], dict[str, list[BaseMetadata]]]
+PIPELINE_MAPPED_DATASET_ITEMS = dict[str, dict[str, list[BaseMetadata]]]
+MAPPED_DATASET_ITEMS = dict[str, PIPELINE_MAPPED_DATASET_ITEMS]
+
+MAPPING_PROCESSOR_TYPE: TypeAlias = Callable[[dict[str, list[BaseMetadata]], str | None], None]
+DECORATOR_TYPE: TypeAlias = Callable[[MAPPING_PROCESSOR_TYPE, MAPPED_DATASET_ITEMS], None]
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+def flatten_middle_mapping(mapping: dict[str, dict[str, dict[T, S]]]) -> dict[str, dict[T, S]]:
+    """
+    Flattens the middle level of a mapping structure.
+
+    Args:
+        mapping: Mapping to flatten.
+
+    Returns:
+        flattened mapping structure.
+    """
+    return {pipeline_name: flatten_mapping(pipeline_data) for pipeline_name, pipeline_data in mapping.items()}
+
+
+def flatten_mapping(mapping: dict[str, dict[T, S]]) -> dict[T, S]:
+    """
+    Flattens a mapping structure for one level.
+
+    Args:
+        mapping: Mapping to flatten.
+
+    Returns:
+        flattened mapping structure.
+    """
+    return reduce(lambda x, y: x | y, mapping.values(), {})
 
 
 def get_mapping_processor_decorator(
@@ -47,44 +79,30 @@ def get_mapping_processor_decorator(
 
 def _run_mapping_processor(
     dataset_mapping_processor: MAPPING_PROCESSOR_TYPE,
-    dataset_mapping: DATASET_MAPPING_TYPE,
-) -> dict[str, list[BaseMetadata]]:
-    pipeline_dataset_mapping = _reduce_dataset_mapping(dataset_mapping)
-    return dataset_mapping_processor(pipeline_dataset_mapping, None)
-
-
-def _reduce_dataset_mapping(dataset_mapping: DATASET_MAPPING_TYPE) -> PIPELINE_DATASET_MAPPING_TYPE:
-    return {
-        pipeline_name: reduce(lambda x, y: x | y, pipeline_data.values(), {})
-        for pipeline_name, pipeline_data in dataset_mapping.items()
-    }
+    collection_dataset_mapping: MAPPED_DATASET_ITEMS,
+) -> None:
+    pipeline_dataset_mapping = flatten_middle_mapping(collection_dataset_mapping)
+    dataset_mapping = flatten_mapping(pipeline_dataset_mapping)
+    return dataset_mapping_processor(dataset_mapping, None)
 
 
 def _run_mapping_processor_per_pipeline(
     dataset_mapping_processor: MAPPING_PROCESSOR_TYPE,
-    dataset_mapping: DATASET_MAPPING_TYPE,
-) -> dict[str, list[BaseMetadata]]:
-    dataset_items: dict[str, list[BaseMetadata]] = {}
-    for pipeline_name, pipeline_data in dataset_mapping.items():
-        pipeline_mapping = _reduce_dataset_mapping({pipeline_name: pipeline_data})
-        collection_dataset_items = dataset_mapping_processor(pipeline_mapping, f"{pipeline_name}")
-        dataset_items = dataset_items | collection_dataset_items
+    collection_dataset_mapping: MAPPED_DATASET_ITEMS,
+) -> None:
+    pipeline_dataset_mapping = flatten_middle_mapping(collection_dataset_mapping)
 
-    return dataset_items
+    for pipeline_name, pipeline_data in pipeline_dataset_mapping.items():
+        dataset_mapping_processor(pipeline_data, f"{pipeline_name}")
 
 
 def _run_mapping_processor_per_pipline_and_collection(
     dataset_mapping_processor: MAPPING_PROCESSOR_TYPE,
-    dataset_mapping: DATASET_MAPPING_TYPE,
-) -> dict[str, list[BaseMetadata]]:
-    dataset_items: dict[str, list[BaseMetadata]] = {}
+    dataset_mapping: MAPPED_DATASET_ITEMS,
+) -> None:
     for pipeline_name, pipeline_mapping in dataset_mapping.items():
         for collection_name, collection_data in pipeline_mapping.items():
-            collection_mapping = {pipeline_name: collection_data}
-            collection_dataset_items = dataset_mapping_processor(
-                collection_mapping,
+            dataset_mapping_processor(
+                collection_data,
                 f"{collection_name}.{pipeline_name}",
             )
-            dataset_items = dataset_items | collection_dataset_items
-
-    return dataset_items

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -1079,7 +1079,7 @@ class ProjectWrapper(LogMixin):
             str,
             dict[str, dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]],
         ],
-        metadata_mapping_processor_decorator: DECORATOR_TYPE,
+        metadata_mapping_processor_decorator: list[DECORATOR_TYPE],
         operation: Operation = Operation.copy,
         version: str | None = "1.0",
         contact_name: str | None = None,

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -48,6 +48,7 @@ from rich.progress import Progress, SpinnerColumn
 from marimba.core.parallel.pipeline_loader import load_pipeline_instance
 from marimba.core.schemas.base import BaseMetadata
 from marimba.core.utils.constants import Operation
+from marimba.core.utils.dataset import DECORATOR_TYPE
 from marimba.core.utils.log import LogMixin, get_file_handler
 from marimba.core.utils.paths import format_path_for_logging, remove_directory_tree
 from marimba.core.utils.prompt import prompt_schema
@@ -1078,6 +1079,7 @@ class ProjectWrapper(LogMixin):
             str,
             dict[str, dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]],
         ],
+        metadata_mapping_processor_decorator: DECORATOR_TYPE,
         operation: Operation = Operation.copy,
         version: str | None = "1.0",
         contact_name: str | None = None,
@@ -1092,6 +1094,7 @@ class ProjectWrapper(LogMixin):
         Args:
             dataset_name: The name of the dataset to be created.
             dataset_mapping: A dictionary containing the dataset mapping information.
+            metadata_mapping_processor_decorator: Dataset mapping processor decorator.
             operation: The operation to perform on files (copy, move or link). Defaults to Operation.copy.
             version: The version of the dataset. Defaults to '1.0'.
             contact_name: The name of the contact person for the dataset. Defaults to None.
@@ -1131,6 +1134,7 @@ class ProjectWrapper(LogMixin):
             self.pipelines_dir,
             self.log_path,
             (pw.log_path for pw in self.pipeline_wrappers.values()),
+            metadata_mapping_processor_decorator,
             operation=operation,
             zoom=zoom,
             max_workers=max_workers,

--- a/marimba/main.py
+++ b/marimba/main.py
@@ -222,8 +222,8 @@ def package_command(
         help="Maximum number of worker processes to use. If None, uses all available CPU cores.",
     ),
     metadata_output: MetadataSaverTypes | None = typer.Option(None, help="Output metadata format"),
-    metadata_level: MetadataGenerationLevelOptions = typer.Option(
-        MetadataGenerationLevelOptions.project,
+    metadata_level: list[MetadataGenerationLevelOptions] | None = typer.Option(
+        None,
         help="Output metadata level",
     ),
 ) -> None:
@@ -240,7 +240,10 @@ def package_command(
     pipeline_names = pipeline_name if pipeline_name else list(project_wrapper.pipeline_wrappers.keys())
 
     metadata_saver_overwrite = None if metadata_output is None else get_saver(metadata_output)
-    metadata_mapping_processor_decorator = get_mapping_processor_decorator(metadata_level)
+    metadata_level_option: list[MetadataGenerationLevelOptions] = metadata_level or [
+        MetadataGenerationLevelOptions.project,
+    ]
+    metadata_mapping_processor_decorator = [get_mapping_processor_decorator(level) for level in metadata_level_option]
     try:
         # Compose the dataset
         dataset_mapping = project_wrapper.compose(

--- a/marimba/main.py
+++ b/marimba/main.py
@@ -42,7 +42,8 @@ from rich import print
 
 from marimba.core.cli import delete, new
 from marimba.core.distribution.base import DistributionTargetBase
-from marimba.core.utils.constants import PROJECT_DIR_HELP, Operation
+from marimba.core.utils.constants import PROJECT_DIR_HELP, MetadataGenerationLevelOptions, Operation
+from marimba.core.utils.dataset import get_mapping_processor_decorator
 from marimba.core.utils.log import LogLevel, get_logger, get_rich_handler
 from marimba.core.utils.map import NetworkConnectionError
 from marimba.core.utils.metadata import MetadataSaverTypes, get_saver
@@ -221,6 +222,10 @@ def package_command(
         help="Maximum number of worker processes to use. If None, uses all available CPU cores.",
     ),
     metadata_output: MetadataSaverTypes | None = typer.Option(None, help="Output metadata format"),
+    metadata_level: MetadataGenerationLevelOptions = typer.Option(
+        MetadataGenerationLevelOptions.project,
+        help="Output metadata level",
+    ),
 ) -> None:
     """
     Package up a Marimba collection ready for distribution.
@@ -235,7 +240,7 @@ def package_command(
     pipeline_names = pipeline_name if pipeline_name else list(project_wrapper.pipeline_wrappers.keys())
 
     metadata_saver_overwrite = None if metadata_output is None else get_saver(metadata_output)
-
+    metadata_mapping_processor_decorator = get_mapping_processor_decorator(metadata_level)
     try:
         # Compose the dataset
         dataset_mapping = project_wrapper.compose(
@@ -250,6 +255,7 @@ def package_command(
         dataset_wrapper = project_wrapper.create_dataset(
             dataset_name,
             dataset_mapping,
+            metadata_mapping_processor_decorator,
             operation=operation,
             version=version,
             contact_name=contact_name,

--- a/tests/core/utils/test_dataset.py
+++ b/tests/core/utils/test_dataset.py
@@ -15,6 +15,7 @@ from marimba.core.utils.dataset import (
     flatten_middle_mapping,
     MAPPED_DATASET_ITEMS,
     MAPPED_GROUPED_ITEMS,
+    flatten_mapping,
 )
 
 
@@ -32,18 +33,25 @@ def test_get_mapping_processor_decorator():
         get_mapping_processor_decorator("bla")  # type: ignore
 
 
+def test_flatten_middle_mapping():
+    mapping = {"a": {"b": {"c": 1}, "d": {"e": 1}}}
+    assert flatten_middle_mapping(mapping) == {"a": {"c": 1, "e": 1}}
+
+
 def test_flatten_mapping():
-    mapping = {"a": {"b": {"c": 1}}}
-    assert flatten_middle_mapping(mapping) == {"a": {"c": 1}}
+    mapping = {"a": {"b": 1}, "c": {"d": 1}}
+    assert flatten_mapping(mapping) == {"b": 1, "d": 1}
 
 
 def test_run_mapping_processor():
     def dataset_mapping_processor(
         dataset_mapping: dict[type[BaseMetadata], dict[str, list[BaseMetadata]]], _: str | None
     ) -> None:
-        assert dataset_mapping == {GenericMetadata: {"a": []}}
+        assert dataset_mapping == {GenericMetadata: {"a": [], "b": []}}
 
-    dataset_mapping: MAPPED_GROUPED_ITEMS = {"pipeline": {"collection": {GenericMetadata: {"a": []}}}}
+    dataset_mapping: MAPPED_GROUPED_ITEMS = {
+        "pipeline": {"collection": {GenericMetadata: {"a": []}}, "another": {GenericMetadata: {"b": []}}}
+    }
     _run_mapping_processor(dataset_mapping_processor, dataset_mapping)
 
 
@@ -51,10 +59,12 @@ def test_run_mapping_processor_per_pipeline():
     def dataset_mapping_processor(
         dataset_mapping: dict[type[BaseMetadata], dict[str, list[BaseMetadata]]], collection_name: str | None
     ) -> None:
-        assert dataset_mapping == {GenericMetadata: {"a": []}}
+        assert dataset_mapping == {GenericMetadata: {"a": [], "b": []}}
         assert collection_name == "pipeline"
 
-    dataset_mapping: MAPPED_GROUPED_ITEMS = {"pipeline": {"collection": {GenericMetadata: {"a": []}}}}
+    dataset_mapping: MAPPED_GROUPED_ITEMS = {
+        "pipeline": {"collection": {GenericMetadata: {"a": []}}, "another": {GenericMetadata: {"b": []}}}
+    }
     _run_mapping_processor_per_pipeline(dataset_mapping_processor, dataset_mapping)
 
 

--- a/tests/core/utils/test_dataset.py
+++ b/tests/core/utils/test_dataset.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from marimba.core.schemas.base import BaseMetadata
+from marimba.core.utils.constants import MetadataGenerationLevelOptions
+from marimba.core.utils.dataset import (
+    DATASET_MAPPING_TYPE,
+    _run_mapping_processor,
+    _run_mapping_processor_per_pipeline,
+    _run_mapping_processor_per_pipline_and_collection,
+    get_mapping_processor_decorator,
+    PIPELINE_DATASET_MAPPING_TYPE,
+)
+
+
+def test_get_mapping_processor_decorator():
+    assert get_mapping_processor_decorator(MetadataGenerationLevelOptions.project) == _run_mapping_processor
+    assert (
+        get_mapping_processor_decorator(MetadataGenerationLevelOptions.pipeline) == _run_mapping_processor_per_pipeline
+    )
+    assert (
+        get_mapping_processor_decorator(MetadataGenerationLevelOptions.collection)
+        == _run_mapping_processor_per_pipline_and_collection
+    )
+
+    with pytest.raises(TypeError):
+        get_mapping_processor_decorator("bla")  # type: ignore
+
+
+def test_run_mapping_processor():
+    def dataset_mapping_processor(
+        dataset_mapping: PIPELINE_DATASET_MAPPING_TYPE, _: str | None
+    ) -> dict[str, list[BaseMetadata]]:
+        assert dataset_mapping == {"pipeline": {Path("tmp"): (Path("tmp"), None, None)}}
+        return {}
+
+    dataset_mapping: DATASET_MAPPING_TYPE = {"pipeline": {"collection": {Path("tmp"): (Path("tmp"), None, None)}}}
+    _run_mapping_processor(dataset_mapping_processor, dataset_mapping)
+
+
+def test_run_mapping_processor_per_pipeline():
+    def dataset_mapping_processor(
+        dataset_mapping: PIPELINE_DATASET_MAPPING_TYPE, collection_name: str | None
+    ) -> dict[str, list[BaseMetadata]]:
+        assert dataset_mapping == {"pipeline": {Path("tmp"): (Path("tmp"), None, None)}}
+        assert collection_name == "pipeline"
+
+        return {}
+
+    dataset_mapping: DATASET_MAPPING_TYPE = {"pipeline": {"collection": {Path("tmp"): (Path("tmp"), None, None)}}}
+    _run_mapping_processor_per_pipeline(dataset_mapping_processor, dataset_mapping)
+
+
+def test_run_mapping_processor_per_pipline_and_collection():
+    def dataset_mapping_processor(
+        dataset_mapping: PIPELINE_DATASET_MAPPING_TYPE, collection_name: str | None
+    ) -> dict[str, list[BaseMetadata]]:
+        assert dataset_mapping == {"pipeline": {Path("tmp"): (Path("tmp"), None, None)}}
+        assert collection_name == "collection.pipeline"
+        return {}
+
+    dataset_mapping: DATASET_MAPPING_TYPE = {"pipeline": {"collection": {Path("tmp"): (Path("tmp"), None, None)}}}
+    _run_mapping_processor_per_pipline_and_collection(dataset_mapping_processor, dataset_mapping)

--- a/tests/core/utils/test_dataset.py
+++ b/tests/core/utils/test_dataset.py
@@ -11,6 +11,8 @@ from marimba.core.utils.dataset import (
     _run_mapping_processor_per_pipline_and_collection,
     get_mapping_processor_decorator,
     PIPELINE_DATASET_MAPPING_TYPE,
+    flatten_middle_mapping,
+    MAPPED_DATASET_ITEMS,
 )
 
 
@@ -28,37 +30,32 @@ def test_get_mapping_processor_decorator():
         get_mapping_processor_decorator("bla")  # type: ignore
 
 
-def test_run_mapping_processor():
-    def dataset_mapping_processor(
-        dataset_mapping: PIPELINE_DATASET_MAPPING_TYPE, _: str | None
-    ) -> dict[str, list[BaseMetadata]]:
-        assert dataset_mapping == {"pipeline": {Path("tmp"): (Path("tmp"), None, None)}}
-        return {}
+def test_flatten_mapping():
+    mapping = {"a": {"b": {"c": 1}}}
+    assert flatten_middle_mapping(mapping) == {"a": {"c": 1}}
 
-    dataset_mapping: DATASET_MAPPING_TYPE = {"pipeline": {"collection": {Path("tmp"): (Path("tmp"), None, None)}}}
+
+def test_run_mapping_processor():
+    def dataset_mapping_processor(dataset_mapping: dict[str, list[BaseMetadata]], _: str | None) -> None:
+        assert dataset_mapping == {"a": []}
+
+    dataset_mapping: MAPPED_DATASET_ITEMS = {"pipeline": {"collection": {"a": []}}}
     _run_mapping_processor(dataset_mapping_processor, dataset_mapping)
 
 
 def test_run_mapping_processor_per_pipeline():
-    def dataset_mapping_processor(
-        dataset_mapping: PIPELINE_DATASET_MAPPING_TYPE, collection_name: str | None
-    ) -> dict[str, list[BaseMetadata]]:
-        assert dataset_mapping == {"pipeline": {Path("tmp"): (Path("tmp"), None, None)}}
+    def dataset_mapping_processor(dataset_mapping: dict[str, list[BaseMetadata]], collection_name: str | None) -> None:
+        assert dataset_mapping == {"a": []}
         assert collection_name == "pipeline"
 
-        return {}
-
-    dataset_mapping: DATASET_MAPPING_TYPE = {"pipeline": {"collection": {Path("tmp"): (Path("tmp"), None, None)}}}
+    dataset_mapping: MAPPED_DATASET_ITEMS = {"pipeline": {"collection": {"a": []}}}
     _run_mapping_processor_per_pipeline(dataset_mapping_processor, dataset_mapping)
 
 
 def test_run_mapping_processor_per_pipline_and_collection():
-    def dataset_mapping_processor(
-        dataset_mapping: PIPELINE_DATASET_MAPPING_TYPE, collection_name: str | None
-    ) -> dict[str, list[BaseMetadata]]:
-        assert dataset_mapping == {"pipeline": {Path("tmp"): (Path("tmp"), None, None)}}
+    def dataset_mapping_processor(dataset_mapping: dict[str, list[BaseMetadata]], collection_name: str | None) -> None:
+        assert dataset_mapping == {"a": []}
         assert collection_name == "collection.pipeline"
-        return {}
 
-    dataset_mapping: DATASET_MAPPING_TYPE = {"pipeline": {"collection": {Path("tmp"): (Path("tmp"), None, None)}}}
+    dataset_mapping: MAPPED_DATASET_ITEMS = {"pipeline": {"collection": {"a": []}}}
     _run_mapping_processor_per_pipline_and_collection(dataset_mapping_processor, dataset_mapping)

--- a/tests/core/utils/test_dataset.py
+++ b/tests/core/utils/test_dataset.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from marimba.core.schemas.base import BaseMetadata
+from marimba.core.schemas.generic import GenericMetadata
 from marimba.core.utils.constants import MetadataGenerationLevelOptions
 from marimba.core.utils.dataset import (
     DATASET_MAPPING_TYPE,
@@ -13,6 +14,7 @@ from marimba.core.utils.dataset import (
     PIPELINE_DATASET_MAPPING_TYPE,
     flatten_middle_mapping,
     MAPPED_DATASET_ITEMS,
+    MAPPED_GROUPED_ITEMS,
 )
 
 
@@ -36,26 +38,32 @@ def test_flatten_mapping():
 
 
 def test_run_mapping_processor():
-    def dataset_mapping_processor(dataset_mapping: dict[str, list[BaseMetadata]], _: str | None) -> None:
-        assert dataset_mapping == {"a": []}
+    def dataset_mapping_processor(
+        dataset_mapping: dict[type[BaseMetadata], dict[str, list[BaseMetadata]]], _: str | None
+    ) -> None:
+        assert dataset_mapping == {GenericMetadata: {"a": []}}
 
-    dataset_mapping: MAPPED_DATASET_ITEMS = {"pipeline": {"collection": {"a": []}}}
+    dataset_mapping: MAPPED_GROUPED_ITEMS = {"pipeline": {"collection": {GenericMetadata: {"a": []}}}}
     _run_mapping_processor(dataset_mapping_processor, dataset_mapping)
 
 
 def test_run_mapping_processor_per_pipeline():
-    def dataset_mapping_processor(dataset_mapping: dict[str, list[BaseMetadata]], collection_name: str | None) -> None:
-        assert dataset_mapping == {"a": []}
+    def dataset_mapping_processor(
+        dataset_mapping: dict[type[BaseMetadata], dict[str, list[BaseMetadata]]], collection_name: str | None
+    ) -> None:
+        assert dataset_mapping == {GenericMetadata: {"a": []}}
         assert collection_name == "pipeline"
 
-    dataset_mapping: MAPPED_DATASET_ITEMS = {"pipeline": {"collection": {"a": []}}}
+    dataset_mapping: MAPPED_GROUPED_ITEMS = {"pipeline": {"collection": {GenericMetadata: {"a": []}}}}
     _run_mapping_processor_per_pipeline(dataset_mapping_processor, dataset_mapping)
 
 
 def test_run_mapping_processor_per_pipline_and_collection():
-    def dataset_mapping_processor(dataset_mapping: dict[str, list[BaseMetadata]], collection_name: str | None) -> None:
-        assert dataset_mapping == {"a": []}
+    def dataset_mapping_processor(
+        dataset_mapping: dict[type[BaseMetadata], dict[str, list[BaseMetadata]]], collection_name: str | None
+    ) -> None:
+        assert dataset_mapping == {GenericMetadata: {"a": []}}
         assert collection_name == "collection.pipeline"
 
-    dataset_mapping: MAPPED_DATASET_ITEMS = {"pipeline": {"collection": {"a": []}}}
+    dataset_mapping: MAPPED_GROUPED_ITEMS = {"pipeline": {"collection": {GenericMetadata: {"a": []}}}}
     _run_mapping_processor_per_pipline_and_collection(dataset_mapping_processor, dataset_mapping)


### PR DESCRIPTION
Added the optional CLI option `--metadata-level [project|pipeline|collection]` for the command `marimba package` to change the level for which metadata files are generated. 

- The default option `project` will then generate one metadata file for the hole project (or all selected pipelines and collections). 
- If the option is set to `pipeline` the metadata is split in individual metadata files corresponding to the run pipelines.
- If the option is set to `collection` the metadata is split for pipelines and collections (e.g. resulting in `<collection_name>.<pipeline_name>.ifdo.yaml`)

This is achieved by decorating the code responsible for generating the metadata files, depending on the CLI option. First, the `dataset_mapping` dictionary is expanded to map pipeline and collection to the metadata. In case of the `collection` option, the metadata files are generated for each entry in the dictionary. In the other cases, the decorator reduces the `dataset_mapping` to map the pipelines to the metadata and generates the metadata file for each entry in case of the `pipeline` option or for the hole dictionary in case of the `project` option.

This feature addition should not break the behavior of marimba.

---

This PR includes the changes made in PR #11, as the PR would otherwise be broken.
