### PR TITLE
Added post package hook

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,3 +1,5 @@
+from marimba.core.pipeline import BasePipeline
+
 # Pipeline Implementation Guide
 
 A Marimba Pipeline is the core component responsible for processing data from a specific instruments or 
@@ -55,6 +57,8 @@ processing capabilities in the Marimba standard library.
         - [Marimba Packaging Steps](#marimba-packaging-steps)
         - [Multi-Level iFDO Files](#multi-level-ifdo-files)
         - [Multi-Level Summary Files](#multi-level-summary-files)
+   - [Implementing the `_post_package` Method](#implementing-the-_post_package-method)
+     - [Example `_post_package` Implementation](#example-_post_package-implementation)
 5. [Pipeline Implementation Summary](#pipeline-implementation-summary)
    - [Next Steps](#next-steps)
 
@@ -152,6 +156,13 @@ including:
   - Files listed in the data mapping that contain an iFDO will have their metadata saved in a dataset-level iFDO 
     output file named `ifdo.yml`. Additionally, this metadata will be embedded in the EXIF metadata of any included 
     JPG file, adhering to FAIR data standards.
+
+- `_post_package()`:
+  - This method allows for the alterations of the finalized dataset. For example this can be useful to remove sensitive
+    data (e.g. API tokens, passwords etc.) from the dataset before it is being published.
+  - Because the method can modify files after the manifest is created, the entries for the files that the method modified 
+    must be updated in the manifest. Therefore, the method must return the set of files it altered.
+    
 
 ---
 
@@ -1228,7 +1239,10 @@ all processing operations throughout the entire Marimba workflow.
 their SHA256 hashes. This manifest is crucial for validating the integrity of the dataset and ensuring no files were 
 corrupted or altered during packaging.
 
-11. **Dataset Validation**: Once the Dataset has been finalized, it undergoes a validation process to check for any 
+11. **Post Package Hook**: The post-package hooks of the pipelines are run on the finalized dataset, which return a 
+set of paths of files that were changed. The manifest is then updated for these paths.
+
+12. **Dataset Validation**: Once the Dataset has been finalized, it undergoes a validation process to check for any 
 inconsistencies with its manifest. This step is critical to certify that the Dataset is complete and accurate.
 
 When the packaging process is executed using the Marimba package command, these steps are visually tracked in the CLI 
@@ -1245,6 +1259,37 @@ To be written...
 #### Multi-Level Summary Files
 
 To be written...
+
+### Implementing the `_post_package` Method
+The `_post_package` method is automatically called after the dataset is finalized and before the dataset is validated to 
+allow for changes to the dataset contents. Because it is called after the manifest is generated, it must return the 
+paths to the files that were changed so that the manifest can be updated accordingly. Not returning every changed file 
+will cause the dataset validation to fail. This should not be seen as a burden, but as an opportunity to verify that 
+only the intended files have been changed by the `_post_package` method.
+
+#### Example `_post_package` Implementation
+[.env](https://pypi.org/project/python-dotenv/) files are a standard way to manage secrets (e.g. API tokens, passwords) 
+for applications, but should not be published (even on GitHub). In the case of the marimba pipeline, this could be a 
+problem, as the entire pipeline is included in the dataset. To solve this problem, the `_post_package` method can be 
+used to remove all .env files from the dataset before publishing:
+
+```python
+from pathlib import Path
+from marimba.core.pipeline import BasePipeline
+
+class MyPipeline(BasePipeline):
+    def _post_package(self, dataset_dir: Path) -> set[Path]:
+        # Find all paths to .env files in the dataset directory
+        env_file_paths = {Path(path) for path in dataset_dir.glob("**/*/.env")}
+        
+        # Delete all .env files
+        for file_path in env_file_paths:
+            file_path.unlink()
+        
+        # Return all path of changed files; in this case all .env files 
+        return env_file_paths
+
+```
 
 ---
 

--- a/marimba/core/pipeline.py
+++ b/marimba/core/pipeline.py
@@ -265,8 +265,6 @@ class BasePipeline(ABC, LogMixin):
     ) -> dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]:
         """
         `run_package` implementation; override this.
-
-        TODO @<cjackett>: Add docs on how to implement this method.
         """
         raise NotImplementedError
 

--- a/marimba/core/pipeline.py
+++ b/marimba/core/pipeline.py
@@ -201,6 +201,27 @@ class BasePipeline(ABC, LogMixin):
 
         return data_mapping
 
+    def run_post_package(
+        self,
+        dataset_dir: Path,
+    ) -> None:
+        """
+        Post packaging hook, which is called after the metadata files are created.
+
+        Args:
+            dataset_dir: Directory containing the metadata files.
+        """
+        self.logger.info(
+            f"Started {format_command('post package')} command for pipeline {format_entity(self.class_name)} with args "
+            f"dataset_dir={format_path_for_logging(dataset_dir, Path(self._root_path).parents[2])}",
+        )
+
+        self._post_package(dataset_dir)
+
+        self.logger.info(
+            f"Completed {format_command('post package')} command for pipeline {format_entity(self.class_name)}",
+        )
+
     def _import(
         self,
         data_dir: Path,  # noqa: ARG002
@@ -238,8 +259,13 @@ class BasePipeline(ABC, LogMixin):
         **kwargs: dict[str, Any],
     ) -> dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]:
         """
-        `run_compose` implementation; override this.
+        `run_package` implementation; override this.
 
         TODO @<cjackett>: Add docs on how to implement this method.
         """
         raise NotImplementedError
+
+    def _post_package(self, dataset_dir: Path) -> None:
+        """
+        `run_post_package` implementation; override this.
+        """

--- a/marimba/core/pipeline.py
+++ b/marimba/core/pipeline.py
@@ -210,6 +210,9 @@ class BasePipeline(ABC, LogMixin):
 
         Args:
             dataset_dir: Directory containing the metadata files.
+
+        Returns:
+            List of files which where changed by the post packege hook.
         """
         self.logger.info(
             f"Started {format_command('post package')} command for pipeline {format_entity(self.class_name)} with args "

--- a/marimba/core/pipeline.py
+++ b/marimba/core/pipeline.py
@@ -204,7 +204,7 @@ class BasePipeline(ABC, LogMixin):
     def run_post_package(
         self,
         dataset_dir: Path,
-    ) -> None:
+    ) -> set[Path]:
         """
         Post packaging hook, which is called after the metadata files are created.
 
@@ -216,11 +216,13 @@ class BasePipeline(ABC, LogMixin):
             f"dataset_dir={format_path_for_logging(dataset_dir, Path(self._root_path).parents[2])}",
         )
 
-        self._post_package(dataset_dir)
+        changed_files = self._post_package(dataset_dir)
 
         self.logger.info(
             f"Completed {format_command('post package')} command for pipeline {format_entity(self.class_name)}",
         )
+
+        return changed_files
 
     def _import(
         self,
@@ -265,7 +267,11 @@ class BasePipeline(ABC, LogMixin):
         """
         raise NotImplementedError
 
-    def _post_package(self, dataset_dir: Path) -> None:
+    def _post_package(
+        self,
+        dataset_dir: Path,  # noqa: ARG002
+    ) -> set[Path]:
         """
         `run_post_package` implementation; override this.
         """
+        return set()

--- a/marimba/core/schemas/ifdo.py
+++ b/marimba/core/schemas/ifdo.py
@@ -273,7 +273,7 @@ class iFDOMetadata(BaseMetadata):  # noqa: N801
                     progress.advance(task)
 
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
-            task = progress.add_task("[green]Processing files with metadata (4/11)", total=len(dataset_mapping))
+            task = progress.add_task("[green]Processing files with metadata (4/12)", total=len(dataset_mapping))
             process_file(cls, items=dataset_mapping.items(), progress=progress, task=task, logger=log)  # type: ignore[call-arg]
 
     @staticmethod

--- a/marimba/core/utils/manifest.py
+++ b/marimba/core/utils/manifest.py
@@ -125,7 +125,7 @@ class Manifest:
         """
         try:
             # Get relative path without the data/ prefix
-            rel_path = item.resolve().relative_to(directory)
+            rel_path = item.resolve().relative_to(directory.resolve())
             metadata_path = str(rel_path.relative_to("data")) if str(rel_path).startswith("data/") else str(rel_path)
 
             # Try to get hash from metadata first
@@ -362,7 +362,7 @@ class Manifest:
         files.update(subdirectories)
 
         deleted_files = {path for path in files if not path.exists()}
-        relative_deleted_files = {path.relative_to(directory) for path in deleted_files}
+        relative_deleted_files = {path.resolve().relative_to(directory.resolve()) for path in deleted_files}
         self.hashes = {path: value for path, value in self.hashes.items() if path not in relative_deleted_files}
 
         changed_files = files - deleted_files

--- a/marimba/core/utils/manifest.py
+++ b/marimba/core/utils/manifest.py
@@ -313,6 +313,36 @@ class Manifest:
 
         return self == manifest
 
+    def update(
+        self,
+        files: set[Path],
+        directory: Path,
+        exclude_paths: set[Path],
+        logger: logging.Logger | None = None,
+        max_workers: int | None = None,
+    ) -> None:
+        """
+        Updates the entries of the given files.
+
+        Args:
+            files: Files to update.
+            directory: Root directory.
+            exclude_paths: Set of paths to exclude.
+            logger: Logger for recording information.
+            max_workers: Maximum number of worker processes.
+
+        """
+        self.hashes = self._process_files_with_progress(
+            files=list(files),
+            directory=directory,
+            exclude_paths=exclude_paths,
+            dataset_items=None,
+            progress=None,
+            task=None,
+            logger=logger,
+            max_workers=max_workers,
+        )
+
     def __eq__(self, other: object) -> bool:
         """
         Check if two manifests are equal.

--- a/marimba/core/wrappers/dataset.py
+++ b/marimba/core/wrappers/dataset.py
@@ -380,6 +380,7 @@ class DatasetWrapper(LogMixin):
         project_log_path: Path,
         pipeline_log_paths: Iterable[Path],
         mapping_processor_decorator: list[DECORATOR_TYPE],
+        post_package_processors: list[Callable[[Path], None]],
         operation: Operation = Operation.copy,
         zoom: int | None = None,
         max_workers: int | None = None,
@@ -400,6 +401,7 @@ class DatasetWrapper(LogMixin):
             project_log_path: A Path object pointing to the project log file.
             pipeline_log_paths: An iterable of Path objects pointing to individual pipeline log files.
             mapping_processor_decorator: Dataset mapping processor decorator.
+            post_package_processors: Processors which are applied to the dataset after the metadata file is created.
             operation: An Operation enum specifying whether to copy or move files (default: Operation.copy).
             zoom: An optional integer specifying the zoom level for the dataset map generation (default: None).
             max_workers: Maximum number of worker processes to use. If None, uses all available CPU cores.
@@ -422,6 +424,10 @@ class DatasetWrapper(LogMixin):
         self.generate_metadata(dataset_name, mapped_dataset_items, mapping_processor_decorator, max_workers)
 
         dataset_items = flatten_mapping(flatten_middle_mapping(mapped_dataset_items))
+
+        for post_package_processor in post_package_processors:
+            post_package_processor(self.root_dir)
+
         self.generate_dataset_summary(dataset_items)
         # TODO @<cjackett>: Generate summary method currently does not use multithreading
         self._generate_dataset_map(dataset_items, zoom)

--- a/marimba/core/wrappers/dataset.py
+++ b/marimba/core/wrappers/dataset.py
@@ -734,7 +734,7 @@ class DatasetWrapper(LogMixin):
         manifest = Manifest.load(self.manifest_path)
         manifest.update(
             changed_files,
-            self.data_dir,
+            self.root_dir,
             {self.manifest_path, self.log_path},
             logger=self.logger,
             max_workers=max_worker,

--- a/marimba/core/wrappers/dataset.py
+++ b/marimba/core/wrappers/dataset.py
@@ -422,11 +422,8 @@ class DatasetWrapper(LogMixin):
         mapped_dataset_items = self._populate_files(dataset_mapping, operation, max_workers)
         self._process_files_with_metadata(reduced_dataset_mapping, max_workers)
         self.generate_metadata(dataset_name, mapped_dataset_items, mapping_processor_decorator, max_workers)
-
+        self._run_post_package_processors(post_package_processors)
         dataset_items = flatten_mapping(flatten_middle_mapping(mapped_dataset_items))
-
-        for post_package_processor in post_package_processors:
-            post_package_processor(self.root_dir)
 
         self.generate_dataset_summary(dataset_items)
         # TODO @<cjackett>: Generate summary method currently does not use multithreading
@@ -700,7 +697,7 @@ class DatasetWrapper(LogMixin):
         if progress:
             with Progress(SpinnerColumn(), *get_default_columns()) as progress_bar:
                 total_tasks = len(flatten_mapping(flatten_middle_mapping(dataset_items))) + 1
-                task = progress_bar.add_task("[green]Generating dataset metadata (5/11)", total=total_tasks)
+                task = progress_bar.add_task("[green]Generating dataset metadata (5/12)", total=total_tasks)
 
                 processed_items = execute_on_mapping(
                     dataset_items,
@@ -708,7 +705,7 @@ class DatasetWrapper(LogMixin):
                 )
                 grouped_items = execute_on_mapping(processed_items, self._group_by_metadata_type)
 
-                progress_bar.update(task, description="[green]Writing dataset metadata (5/11)")
+                progress_bar.update(task, description="[green]Writing dataset metadata (5/12)")
                 for decorator in mapping_processor_decorator:
                     decorator(lambda x, y: self._create_metadata_files(dataset_name, x, y), grouped_items)
 

--- a/marimba/core/wrappers/dataset.py
+++ b/marimba/core/wrappers/dataset.py
@@ -723,7 +723,10 @@ class DatasetWrapper(LogMixin):
     def _run_post_package_processors(self, post_package_processors: list[Callable[[Path], set[Path]]]) -> set[Path]:
         changed_files = set()
         with Progress(SpinnerColumn(), *get_default_columns()) as progress_bar:
-            task = progress_bar.add_task("[green]Running post package hooks (6/12)", total=len(post_package_processors))
+            task = progress_bar.add_task(
+                "[green]Running post package hooks (11/12)",
+                total=len(post_package_processors),
+            )
             for post_package_processor in post_package_processors:
                 changed_files.update(post_package_processor(self.root_dir))
                 progress_bar.advance(task)
@@ -767,7 +770,7 @@ class DatasetWrapper(LogMixin):
 
         if progress:
             with Progress(SpinnerColumn(), *get_default_columns()) as progress_bar:
-                task = progress_bar.add_task("[green]Generating dataset summary (7/12)", total=1)
+                task = progress_bar.add_task("[green]Generating dataset summary (6/12)", total=1)
                 generate_summary()
                 progress_bar.advance(task)
         else:
@@ -816,7 +819,7 @@ class DatasetWrapper(LogMixin):
             zoom: Optional zoom level for the map.
         """
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
-            task = progress.add_task("[green]Generating dataset map (8/12)", total=1)
+            task = progress.add_task("[green]Generating dataset map (7/12)", total=1)
 
             # Check for geolocations
             geolocations = [
@@ -847,7 +850,7 @@ class DatasetWrapper(LogMixin):
             pipeline_log_paths: The paths to the pipeline log files.
         """
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
-            task = progress.add_task("[green]Copying logs (10/12)", total=1)
+            task = progress.add_task("[green]Copying logs (9/12)", total=1)
             if not self.dry_run:
                 copy2(project_log_path, self.logs_dir)
                 for pipeline_log_path in pipeline_log_paths:
@@ -863,7 +866,7 @@ class DatasetWrapper(LogMixin):
             project_pipelines_dir: The path to the project pipelines directory.
         """
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
-            task = progress.add_task("[green]Copying pipelines (9/12)", total=1)
+            task = progress.add_task("[green]Copying pipelines (8/12)", total=1)
             if not self.dry_run:
                 ignore = ignore_patterns(
                     ".git",
@@ -892,7 +895,7 @@ class DatasetWrapper(LogMixin):
         """
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
             globbed_files = list(self.root_dir.glob("**/*"))
-            task = progress.add_task("[green]Generating manifest (11/12)", total=len(globbed_files))
+            task = progress.add_task("[green]Generating manifest (10/12)", total=len(globbed_files))
             manifest = Manifest.from_dir(
                 self.root_dir,
                 exclude_paths=[self.manifest_path, self.log_path],

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -1081,7 +1081,7 @@ class ProjectWrapper(LogMixin):
             dict[str, dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]],
         ],
         metadata_mapping_processor_decorator: list[DECORATOR_TYPE],
-        post_package_processors: list[Callable[[Path], None]],
+        post_package_processors: list[Callable[[Path], set[Path]]],
         operation: Operation = Operation.copy,
         version: str | None = "1.0",
         contact_name: str | None = None,
@@ -1155,7 +1155,7 @@ class ProjectWrapper(LogMixin):
         self._dataset_wrappers[dataset_name] = dataset_wrapper
         return dataset_wrapper
 
-    def get_pipeline_post_processors(self, pipeline_names: list[str]) -> list[Callable[[Path], None]]:
+    def get_pipeline_post_processors(self, pipeline_names: list[str]) -> list[Callable[[Path], set[Path]]]:
         """
         Gets the post processor methods for all given pipeline names.
 

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -1029,7 +1029,7 @@ class ProjectWrapper(LogMixin):
 
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
             total_task_length = len(self.pipeline_wrappers) * len(collection_wrappers)
-            task = progress.add_task("[green]Composing data (1/11)", total=total_task_length)
+            task = progress.add_task("[green]Composing data (1/12)", total=total_task_length)
 
             with ProcessPoolExecutor(max_workers=max_workers) as executor:
                 futures = self._create_composition_tasks(
@@ -1147,7 +1147,7 @@ class ProjectWrapper(LogMixin):
         # Validate it
         with Progress(SpinnerColumn(), *get_default_columns()) as progress:
             globbed_files = list(dataset_wrapper.root_dir.glob("**/*"))
-            task = progress.add_task("[green]Validating dataset (11/11)", total=len(globbed_files))
+            task = progress.add_task("[green]Validating dataset (12/12)", total=len(globbed_files))
             dataset_wrapper.validate(progress, task)
             dataset_wrapper.logger.info(f'Packaged dataset "{dataset_name}" has been validated against the manifest')
             progress.advance(task)

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -46,6 +46,7 @@ from typing import Any
 from rich.progress import Progress, SpinnerColumn
 
 from marimba.core.parallel.pipeline_loader import load_pipeline_instance
+from marimba.core.pipeline import BasePipeline
 from marimba.core.schemas.base import BaseMetadata
 from marimba.core.utils.constants import Operation
 from marimba.core.utils.dataset import DECORATOR_TYPE
@@ -1080,6 +1081,7 @@ class ProjectWrapper(LogMixin):
             dict[str, dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]],
         ],
         metadata_mapping_processor_decorator: list[DECORATOR_TYPE],
+        post_package_processors: list[Callable[[Path], None]],
         operation: Operation = Operation.copy,
         version: str | None = "1.0",
         contact_name: str | None = None,
@@ -1095,6 +1097,7 @@ class ProjectWrapper(LogMixin):
             dataset_name: The name of the dataset to be created.
             dataset_mapping: A dictionary containing the dataset mapping information.
             metadata_mapping_processor_decorator: Dataset mapping processor decorator.
+            post_package_processors: Processors which are applied to the dataset after the metadata file is created.
             operation: The operation to perform on files (copy, move or link). Defaults to Operation.copy.
             version: The version of the dataset. Defaults to '1.0'.
             contact_name: The name of the contact person for the dataset. Defaults to None.
@@ -1135,6 +1138,7 @@ class ProjectWrapper(LogMixin):
             self.log_path,
             (pw.log_path for pw in self.pipeline_wrappers.values()),
             metadata_mapping_processor_decorator,
+            post_package_processors,
             operation=operation,
             zoom=zoom,
             max_workers=max_workers,
@@ -1150,6 +1154,25 @@ class ProjectWrapper(LogMixin):
 
         self._dataset_wrappers[dataset_name] = dataset_wrapper
         return dataset_wrapper
+
+    def get_pipeline_post_processors(self, pipeline_names: list[str]) -> list[Callable[[Path], None]]:
+        """
+        Gets the post processor methods for all given pipeline names.
+
+        Args:
+            pipeline_names: Pipelines from which to get post processor methods.
+
+        Returns:
+            Post processor methods.
+        """
+        return [self._get_pipeline(pipeline_name).run_post_package for pipeline_name in pipeline_names]
+
+    def _get_pipeline(self, pipeline_name: str) -> BasePipeline:
+        pipeline_wrapper = self._pipeline_wrappers[pipeline_name]
+        pipeline = pipeline_wrapper.get_instance()
+        if pipeline is None:
+            raise ProjectWrapper.NoSuchPipelineError(pipeline_name)
+        return pipeline
 
     def delete_dataset(
         self,

--- a/marimba/main.py
+++ b/marimba/main.py
@@ -259,6 +259,7 @@ def package_command(
             dataset_name,
             dataset_mapping,
             metadata_mapping_processor_decorator,
+            project_wrapper.get_pipeline_post_processors(pipeline_names),
             operation=operation,
             version=version,
             contact_name=contact_name,

--- a/tests/core/utils/test_manifest.py
+++ b/tests/core/utils/test_manifest.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from marimba.core.utils.manifest import Manifest
+
+
+def test_get_subdirectories() -> None:
+    base_dir = Path("tmp")
+    files = {base_dir / "data" / "event" / "image.jpg", base_dir / "data" / "event" / "another.jpg"}
+    sub_directories = Manifest._get_sub_directories(files, base_dir)
+
+    assert sub_directories == {base_dir / "data", base_dir / "data" / "event"}


### PR DESCRIPTION
I found the idea of a post-package hook  (https://github.com/csiro-fair/marimba/issues/13#issuecomment-2739179097)  useful, regardless of how #13 and #14 are ultimately resolved.
Since the package command records the checksum of each file in a dataset, the post package hook cannot really run after the usual package command if the code in the hook is to be allowed to modify files. I decided that it would be most useful to run the hook after the metadata file has been created. It also receives the root directory of the dataset (not the data directory), since the code in the hook should be able to modify the metadata file.

I have not yet modified the documentation (`docs/pipeline.md`), but am willing to do so if the general implementation is accepted.

This feature addition should not break the behavior of marimba.