### PR TITLE
Fixed PyAv package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "staticmap>=0.5.7,<0.6",
     "piexif>=1.1.3,<2",
     "tabulate>=0.9.0,<0.10",
-    "pyav>=14.0.1,<15",
+    "av>=14.0.1,<15",
     "distlib>=0.3.8,<0.4",
     "typing-extensions>=4.12.2,<5",
 ]


### PR DESCRIPTION
For some reason the `pyav` project was deleted on pypi, which results marimba installs to fail. 
According to the [PyAv repository](https://github.com/PyAV-Org/PyAV) the right PyPI project is just named `av`.