### PR TITLE
Added dependency check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,14 @@ repos:
         types: [ python ]
         args: [ "--line-length", "120" ]
 
+      - id: deptry
+        name: Deptry
+        entry: uv run deptry
+        language: system
+        files: 'pyproject.toml'
+        pass_filenames: false
+        args : ['.']
+
       - id: mypy
         name: Mypy
         entry: uv run mypy
@@ -41,11 +49,3 @@ repos:
         types: [ python ]
         pass_filenames: false
         args: [ '--rootdir', '.', '-c', 'config/pytest.ini' ]
-
-      - id: deptry
-        name: Deptry
-        entry: uv run deptry
-        language: system
-        files: 'pyproject.toml'
-        pass_filenames: false
-        args : ['.']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,11 @@ repos:
         types: [ python ]
         pass_filenames: false
         args: [ '--rootdir', '.', '-c', 'config/pytest.ini' ]
+
+      - id: deptry
+        name: Deptry
+        entry: uv run deptry
+        language: system
+        files: 'pyproject.toml'
+        pass_filenames: false
+        args : ['.']

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -80,7 +80,7 @@ The Python dependencies for Marimba are managed using [UV](https://github.com/as
 ```bash
 # Install the package in development mode with dev dependencies
 # This creates a virtual environment automatically and installs all dependencies
-uv sync --group dev
+uv sync --group dev --python 3.10
 
 # Activate the virtual environment (if not already activated) on Linux/Mac
 source .venv/bin/activate

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -78,19 +78,14 @@ marimba/
 The Python dependencies for Marimba are managed using [UV](https://github.com/astral-sh/uv), a fast Python package installer and resolver. To set up your development environment:
 
 ```bash
-# Create a new virtual environment with Python 3.10
-uv venv --python=3.10
-
-# Activate the virtual environment
-source .venv/bin/activate  # On Linux/Mac
-# or
-.venv\Scripts\activate  # On Windows
-
-# Update pip
-uv pip install --upgrade pip
-
 # Install the package in development mode with dev dependencies
-uv pip install -e ".[dev]"
+# This creates a virtual environment automatically and installs all dependencies
+uv sync --group dev
+
+# Activate the virtual environment (if not already activated) on Linux/Mac
+source .venv/bin/activate
+# or on Windows
+.venv\Scripts\activate
 ```
 
 This will create a new Python virtual environment, install the package dependencies, and activate the environment. You can confirm the successful activation by running:
@@ -126,15 +121,19 @@ Our pre-commit configuration includes these hooks:
    - Line length: 120 characters
    - Ensures consistent code style
 
-3. **Mypy** - For static type checking
+3. **Deptry** - For dependency validation
+   - Ensures all imports are declared in dependencies
+   - Prevents unused dependency accumulation
+
+4. **Mypy** - For static type checking
    - Configuration: `config/mypy.ini`
    - Verifies type annotations
 
-4. **Bandit** - For security linting
+5. **Bandit** - For security linting
    - Configuration: `config/bandit.yml`
    - Identifies potential security issues
 
-5. **Pytest** - For running tests
+6. **Pytest** - For running tests
    - Configuration: `config/pytest.ini`
    - Ensures your changes don't break existing functionality
 
@@ -149,6 +148,7 @@ pre-commit run --all-files
 # Run a specific hook
 pre-commit run ruff --all-files
 pre-commit run black --all-files
+pre-commit run deptry --all-files
 pre-commit run mypy --all-files
 pre-commit run bandit --all-files
 pre-commit run pytest --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "typer>=0.15.1,<0.16",
     "rich>=13.3.1,<14",
     "PyYAML~=6.0",
-    "pandas>=2.2.2,<3",
     "ifdo>=1.2.5,<2",
     "pillow>=11.1.0,<12",
     "opencv-python-headless>=4.7.0.72,<5",
@@ -24,7 +23,9 @@ dependencies = [
     "tabulate>=0.9.0,<0.10",
     "av>=14.0.1,<15",
     "distlib>=0.3.8,<0.4",
-    "typing-extensions>=4.12.2,<5",
+    "numpy>=2.2.5",
+    "botocore>=1.38.2",
+    "requests>=2.32.3",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ marimba = "marimba.main:marimba_cli"
 "Documentation" = "https://github.com/csiro-fair/marimba/tree/main/docs"
 "Bug Tracker" = "https://github.com/csiro-fair/marimba/issues"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "black>=24.4.2,<25",
     "isort>=5.13.2,<6",
@@ -64,6 +64,7 @@ dev = [
     "ruff>=0.7.0,<0.8",
     "hatch>=1.14.1,<2",
     "twine>=6.1.0,<7",
+    "deptry>=0.23.0",
 ]
 
 [tool.black]
@@ -91,3 +92,9 @@ packages = ["marimba"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "marimba/py.typed" = "marimba/py.typed"
+
+[tool.deptry.package_module_name_map]
+pillow = ["PIL"]
+PyYAML = ["yaml"]
+gitpython = ["git"]
+opencv-python-headless = ["cv2"]


### PR DESCRIPTION
Added [deptry](https://deptry.com/) for checking project dependencies as pre-commit check, because I noticed, that `pandas` was an unused dependency and wondered if any other packages are unused or undeclared.

**Changes**
- Changed dev dependencies from `project.optional-dependencies` to `dependency-groups` to remove "dev" as an extra dependency group
- Added deptry as dev-dependency and pre-commit check
- Removed packages `pandas` & `typing-extensions` as they are unused
- Added packages `numpy`, `botocore` and `requests` as they are transitive dependencies