### PR TITLE
Fixed documentation and dependency groups

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ Follow these steps to set up your development environment:
 2. Install project dependencies:
    ```bash
    # Creates a virtual environment .venv and installs dependencies
-   uv sync --python 3.10
+   uv sync --group dev --python 3.10
    ```
 
 3. Run commands:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ Follow these steps to set up your development environment:
 2. Install project dependencies:
    ```bash
    # Creates a virtual environment .venv and installs dependencies
-   uv sync
+   uv sync --python 3.10
    ```
 
 3. Run commands:
@@ -76,10 +76,10 @@ Follow these steps to set up your development environment:
    # Run pre-commit hooks
    uv run pre-commit run --all-files
 
-   # Or with activate virtual environment
-   source .venv/bin/activate # On Linux/Mac
-   #or
-   .venv/bin/activate # On Windows   
+   # Or with activated virtual environment on Linux/Mac
+    source .venv/bin/activate
+    # or on Windows
+    .venv\Scripts\activate
 
    pre-commit run --all-files
    ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,8 @@
 # Contributing Guide
 
-Thank you for your interest in contributing to Marimba! This guide will help you understand our contribution process and coding standards to ensure your contributions can be efficiently integrated into the project.
+Thank you for your interest in contributing to Marimba! This guide will help you
+understand our contribution process and coding standards to ensure your
+contributions can be efficiently integrated into the project.
 
 ## Table of Contents
 
@@ -29,13 +31,15 @@ Thank you for your interest in contributing to Marimba! This guide will help you
 
 ## Code of Conduct
 
-By participating in this project, you are expected to uphold our Code of Conduct: be respectful, considerate, and collaborative.
+By participating in this project, you are expected to uphold our Code of
+Conduct: be respectful, considerate, and collaborative.
 
 ## Getting Started
 
 ### Fork the Repository
 
-Start by forking the [Marimba repository](https://github.com/csiro-fair/marimba) on GitHub:
+Start by forking the [Marimba repository](https://github.com/csiro-fair/marimba)
+on GitHub:
 
 1. Visit https://github.com/csiro-fair/marimba
 2. Click the "Fork" button in the top-right corner
@@ -52,27 +56,32 @@ cd marimba
 
 ### Set Up the Development Environment
 
-Marimba uses [UV](https://github.com/astral-sh/uv) for dependency management. Follow these steps to set up your development environment:
+Marimba uses [UV](https://github.com/astral-sh/uv) for dependency management.
+Follow these steps to set up your development environment:
 
-1. Install UV if you haven't already:
+1. Install UV if you haven't already
+   ([Install Guide](https://docs.astral.sh/uv/getting-started/installation/)):
    ```bash
    pip install uv
    ```
 
-2. Create and activate a virtual environment:
+2. Install project dependencies:
    ```bash
-   # Create a virtual environment
-   uv venv --python=3.10
-   
-   # Activate the virtual environment
-   source .venv/bin/activate  # On Linux/Mac
-   # or
-   .venv\Scripts\activate     # On Windows
+   # Creates a virtual environment .venv and installs dependencies
+   uv sync
    ```
 
-3. Install the project dependencies:
+3. Run commands:
    ```bash
-   uv pip install -e ".[dev]"
+   # Run pre-commit hooks
+   uv run pre-commit run --all-files
+
+   # Or with activate virtual environment
+   source .venv/bin/activate # On Linux/Mac
+   #or
+   .venv/bin/activate # On Windows   
+
+   pre-commit run --all-files
    ```
 
 ## Development Workflow
@@ -89,7 +98,8 @@ Use a descriptive branch name that reflects the purpose of your changes.
 
 ### Make Your Changes
 
-Now you can make changes to the codebase. Be sure to follow our [Code Standards](#code-standards).
+Now you can make changes to the codebase. Be sure to follow our
+[Code Standards](#code-standards).
 
 ### Commit Your Changes
 
@@ -100,7 +110,8 @@ git add .
 git commit -m "Add a descriptive commit message"
 ```
 
-Our pre-commit hooks will automatically run when you commit, ensuring your code meets our standards.
+Our pre-commit hooks will automatically run when you commit, ensuring your code
+meets our standards.
 
 ### Push Changes to Your Fork
 
@@ -114,7 +125,8 @@ git push origin feature/your-feature-name
 
 Once your changes are pushed to your fork, you can create a pull request:
 
-1. Go to the [original Marimba repository](https://github.com/csiro-fair/marimba)
+1. Go to the
+   [original Marimba repository](https://github.com/csiro-fair/marimba)
 2. Click "Pull Requests" and then "New Pull Request"
 3. Click "compare across forks" and select your fork and branch
 4. Click "Create Pull Request"
@@ -129,17 +141,21 @@ Marimba follows a strict code style to maintain consistency across the codebase:
 
 - **Line Length**: Maximum line length is 120 characters
 - **Python Version**: All code must be compatible with Python 3.10+
-- **Formatting**: We use [Black](https://black.readthedocs.io/) for consistent code formatting
-- **Linting**: We use [Ruff](https://github.com/charliermarsh/ruff) for linting with our custom configuration
+- **Formatting**: We use [Black](https://black.readthedocs.io/) for consistent
+  code formatting
+- **Linting**: We use [Ruff](https://github.com/charliermarsh/ruff) for linting
+  with our custom configuration
 
 ### Type Hints
 
-Marimba uses type hints extensively to improve code quality and development experience:
+Marimba uses type hints extensively to improve code quality and development
+experience:
 
 - All functions and methods should include type annotations
 - Use Python 3.10+ type hint syntax (e.g., `X | Y` instead of `Union[X, Y]`)
 - Function return types must be explicitly annotated
-- Use built-in types like `dict`, `list` rather than imports from the `typing` module
+- Use built-in types like `dict`, `list` rather than imports from the `typing`
+  module
 
 Example:
 
@@ -154,7 +170,9 @@ def process_data(data: list[dict[str, str]], limit: int | None = None) -> dict[s
 
 Good documentation is essential:
 
-- All modules, classes, methods, and functions should have docstrings following the [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
+- All modules, classes, methods, and functions should have docstrings following
+  the
+  [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 - Include examples in docstrings where appropriate
 - Update relevant documentation files when adding or changing features
 
@@ -167,11 +185,16 @@ Ideally, all code should be covered by tests:
 - Tests should be placed in the `tests/` directory
 - Use [pytest](https://docs.pytest.org/) for writing and running tests
 
-Note: With the rapid rise of automated testing capabilities powered by large language models, we will be looking to upgrade the codebase with more comprehensive testing as a separate project in the future. However, basic testing for critical components is still expected for new contributions.
+Note: With the rapid rise of automated testing capabilities powered by large
+language models, we will be looking to upgrade the codebase with more
+comprehensive testing as a separate project in the future. However, basic
+testing for critical components is still expected for new contributions.
 
 ## Pre-commit Hooks
 
-Marimba uses pre-commit hooks to enforce code quality standards automatically. These hooks run when you commit changes, ensuring that your code meets our standards before it's committed.
+Marimba uses pre-commit hooks to enforce code quality standards automatically.
+These hooks run when you commit changes, ensuring that your code meets our
+standards before it's committed.
 
 ### Available Hooks
 
@@ -202,7 +225,8 @@ We use the following pre-commit hooks:
 
 ### Running Pre-commit Hooks
 
-Pre-commit hooks run automatically when you commit changes. You can also run them manually:
+Pre-commit hooks run automatically when you commit changes. You can also run
+them manually:
 
 ```bash
 # Run all hooks on all files
@@ -220,13 +244,15 @@ If a hook fails, fix the issues and try committing again.
 
 #### Ruff Configuration
 
-Marimba uses a custom Ruff configuration with rules carefully selected for our project. Key points:
+Marimba uses a custom Ruff configuration with rules carefully selected for our
+project. Key points:
 
 - Targets Python 3.10+
 - Uses a line length of 120 characters
 - Follows the Google docstring convention
 - Excludes certain directories (tests, docs, etc.)
-- Ignores specific rules that don't align with our workflow (detailed in `config/.ruff.toml`)
+- Ignores specific rules that don't align with our workflow (detailed in
+  `config/.ruff.toml`)
 
 #### Mypy Configuration
 
@@ -260,8 +286,10 @@ If you find a bug or want to request a feature:
 
 ## License
 
-By contributing to Marimba, you agree that your contributions will be licensed under the project's [CSIRO BSD/MIT License](../LICENSE).
+By contributing to Marimba, you agree that your contributions will be licensed
+under the project's [CSIRO BSD/MIT License](../LICENSE).
 
 ---
 
-Thank you for contributing to Marimba! Your efforts help improve this tool for the scientific community.
+Thank you for contributing to Marimba! Your efforts help improve this tool for
+the scientific community.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ marimba = "marimba.main:marimba_cli"
 "Documentation" = "https://github.com/csiro-fair/marimba/tree/main/docs"
 "Bug Tracker" = "https://github.com/csiro-fair/marimba/issues"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "black>=24.4.2,<25",
     "isort>=5.13.2,<6",


### PR DESCRIPTION
The documentation for setting up the development environment used the uv pip interface, which is not necessary in this case.

- Simplified environment setup with uv native commands
- Changed development dependencies from project.optional-dependencies to dependency-groups. This simplifies the  environment setup and does not create an extra group when publishing the project.