### PR TITLE
Added uv as a project dependency (hotfix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "av>=14.0.1,<15",
     "distlib>=0.3.8,<0.4",
     "typing-extensions>=4.12.2,<5",
+    "uv>=0.7.8",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
As marimba now uses uv to install pipeline dependencies
https://github.com/csiro-fair/marimba/blob/3a7e60a6a7177b4acf879e6ef1cc2c5f5ef801b2/marimba/core/wrappers/pipeline.py#L430

it should be included in the project dependencies.