### PR TITLE
[Docs] Write user and API guides and refresh existing documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # All files require review from a core maintainer
-* @cjackett @kevinsbarnard
+* @cjackett
 
 # CI/CD workflows
-/.github/workflows/ @cjackett @kevinsbarnard
+/.github/workflows/ @cjackett
 
 # Dependencies and build
-/pyproject.toml @cjackett @kevinsbarnard
-/uv.lock @cjackett @kevinsbarnard
+/pyproject.toml @cjackett
+/uv.lock @cjackett

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -48,8 +48,8 @@ Tensions can occur between community members even when they are trying their bes
 
 When an incident does occur, it is important to report it promptly. To report a possible violation, please email the project maintainers directly:
 
-- **Chris Jackett** — chris.jackett@csiro.au
-- **Kevin Barnard** — kbarnard@mbari.org
+- **Chris Jackett**: chris.jackett@csiro.au
+- **Kevin Barnard**: kbarnard@mbari.org
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,9 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 1.1.x   | :white_check_mark: |
-| 1.0.x   | :x:                |
-| < 1.0   | :x:                |
+| 1.2.x   | :white_check_mark: |
+| < 1.2   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -14,8 +13,8 @@ Please **do not** report security vulnerabilities through public GitHub issues.
 
 Instead, email the maintainers directly:
 
-- **Chris Jackett** — chris.jackett@csiro.au
-- **Kevin Barnard** — kbarnard@mbari.org
+- **Chris Jackett**: chris.jackett@csiro.au
+- **Kevin Barnard**: kbarnard@mbari.org
 
 Include a description of the vulnerability and its potential impact, steps to reproduce or proof-of-concept code, and any suggested mitigation. You should receive a response within 10 business days. We aim to release a patch within 30 days of a confirmed vulnerability.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ processing:
 - **Standard Image and Video Library:**
   - Marimba provides a comprehensive standard library of image and video processing modules that can:
     - Convert, compress and resize imagery using [Pillow](https://pypi.org/project/Pillow/)
-    - Transcode, segment and extract frames from videos using [FFmpeg](https://ffmpeg.org/)
+    - Transcode, segment and extract frames from videos using [PyAV](https://pyav.org/)
     - Automatically generate thumbnails for images and videos and create composite overview images for rapid assessment 
     of image datasets
     - Detect duplicate, blurry, or improperly exposed images using 
@@ -150,7 +150,7 @@ marimba
 
 ### System Dependencies
 
-Marimba requires two system-level dependencies for its operation:
+Marimba requires one system-level dependency for its operation:
 
 - **ExifTool**: Required for EXIF metadata reading and writing
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,614 @@
-# Coming Soon
+# Marimba API Reference
 
-This section is under development and will be available shortly.
+This reference documents the Marimba Python API for developers who want to build pipelines, drive Marimba
+programmatically, or integrate it into larger applications. It covers the pipeline base class you subclass, the metadata
+classes you emit, the standard library of processing helpers, the wrapper classes that manage projects and datasets, and
+the exception and logging conventions. For a narrative tutorial on building a pipeline, read the
+[Pipeline Implementation Guide](pipeline.md) alongside this reference; for the command-line surface, see the
+[Overview and CLI Usage Guide](overview.md).
+
+All signatures below reflect Marimba v1.2.0. The authoritative source is always the code itself; where a method has many
+parameters, only those relevant to typical use are highlighted in prose.
 
 ---
 
-In the meantime, perhaps you might enjoy some [Keiko Abe playing the marimba](https://open.spotify.com/artist/7Gbxp2rkJ1RpBoI86e9UAF?si=xa-RdgcCSWyDIoxymxIj5A).
+## Table of Contents
 
-*Note: Keiko Abe is a renowned Japanese marimba player and composer who helped establish the marimba as a respected concert instrument.*
+1. [API Overview](#api-overview)
+2. [Building a Pipeline: `BasePipeline`](#building-a-pipeline-basepipeline)
+   - [Constructor and Metadata Class](#constructor-and-metadata-class)
+   - [Configuration Schemas](#configuration-schemas)
+   - [Lifecycle Methods](#lifecycle-methods)
+   - [The `_package` Return Mapping](#the-_package-return-mapping)
+   - [Runtime Helpers](#runtime-helpers)
+3. [Metadata Classes](#metadata-classes)
+   - [`BaseMetadata`](#basemetadata)
+   - [`iFDOMetadata`](#ifdometadata)
+   - [`DarwinCoreMetadata` and `GenericMetadata`](#darwincoremetadata-and-genericmetadata)
+4. [Standard Library](#standard-library)
+   - [`marimba.lib.image`](#marimbalibimage)
+   - [`marimba.lib.gps`](#marimbalibgps)
+   - [`marimba.lib.exif`](#marimbalibexif)
+5. [A Complete Worked Example](#a-complete-worked-example)
+6. [Driving Marimba Programmatically](#driving-marimba-programmatically)
+   - [`ProjectWrapper`](#projectwrapper)
+   - [`PipelineWrapper`](#pipelinewrapper)
+   - [`CollectionWrapper`](#collectionwrapper)
+   - [`DatasetWrapper`](#datasetwrapper)
+   - [`DistributionTargetWrapper`](#distributiontargetwrapper)
+7. [Exceptions](#exceptions)
+8. [Logging](#logging)
+
+---
+
+## API Overview
+
+Marimba's public API has two layers:
+
+- **The pipeline API**: the `BasePipeline` class and the metadata classes. This is what you implement to add support
+  for a new instrument, and it is what most developers work with. A pipeline is a self-contained Git repository
+  containing a single `BasePipeline` subclass.
+- **The wrapper API**: `ProjectWrapper`, `PipelineWrapper`, `CollectionWrapper`, `DatasetWrapper` and
+  `DistributionTargetWrapper`. These manage the on-disk project structure and implement the operations the CLI exposes.
+  Use them when you want to drive Marimba from Python rather than the command line.
+
+The common imports:
+
+```python
+from marimba.core.pipeline import BasePipeline
+from marimba.core.schemas.ifdo import iFDOMetadata
+from marimba.core.wrappers.project import ProjectWrapper
+from marimba.core.utils.constants import Operation
+from marimba.core.utils.log import get_logger
+```
+
+---
+
+## Building a Pipeline: `BasePipeline`
+
+`BasePipeline` (in `marimba.core.pipeline`) is the abstract base class that every pipeline subclasses. It defines the
+import, process and package lifecycle, wires up per-pipeline logging and dry-run handling, and gives your code access to
+its static configuration.
+
+### Constructor and Metadata Class
+
+```python
+class BasePipeline(ABC, LogMixin):
+    def __init__(
+        self,
+        root_path: str | Path,
+        config: dict[str, Any] | None = None,
+        metadata_class: type[BaseMetadata] = BaseMetadata,
+        *,
+        dry_run: bool = False,
+    ) -> None: ...
+```
+
+Subclasses override `__init__` to fix the `metadata_class` their pipeline emits, almost always `iFDOMetadata`, and
+forward the remaining arguments to `super().__init__`:
+
+```python
+from pathlib import Path
+from typing import Any
+
+from marimba.core.pipeline import BasePipeline
+from marimba.core.schemas.ifdo import iFDOMetadata
+
+
+class MyPipeline(BasePipeline):
+    def __init__(
+        self,
+        root_path: str | Path,
+        config: dict[str, Any] | None = None,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(root_path, config, dry_run=dry_run, metadata_class=iFDOMetadata)
+```
+
+The chosen class is available at runtime as `self._metadata_class`, so `_package` can construct metadata without
+hard-coding the type.
+
+### Configuration Schemas
+
+Two static methods declare the configuration Marimba prompts for. Each returns a dict mapping field names to default
+values; return an empty dict if a level needs no configuration.
+
+```python
+@staticmethod
+def get_pipeline_config_schema() -> dict[str, Any]: ...
+
+@staticmethod
+def get_collection_config_schema() -> dict[str, Any]: ...
+```
+
+- `get_pipeline_config_schema()` - values constant across all collections (for example a platform identifier). Prompted
+  at `marimba new pipeline` and stored in `pipeline.yml`.
+- `get_collection_config_schema()` - values specific to a single import (for example a deployment identifier). Prompted
+  at `marimba import` and stored in `collection.yml`.
+
+### Lifecycle Methods
+
+You override three lifecycle methods. Only `_package` is abstract and must be implemented; `_import` and `_process` have
+no-op default implementations you override as needed. Marimba calls the public `run_import` / `run_process` /
+`run_package` wrappers, which apply dry-run and logging handling and then invoke your `_`-prefixed methods.
+
+```python
+def _import(self, data_dir: Path, source_path: Path, config: dict[str, Any], **kwargs: Any) -> None: ...
+
+def _process(self, data_dir: Path, config: dict[str, Any], **kwargs: Any) -> None: ...
+
+def _package(
+    self,
+    data_dir: Path,
+    config: dict[str, Any],
+    **kwargs: Any,
+) -> dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]: ...
+```
+
+- **`_import`**: copy, move or link source data from `source_path` into the collection's `data_dir`. Honour
+  `self.dry_run` before writing.
+- **`_process`**: transform the imported data in place within `data_dir` (rename, generate thumbnails, extract frames,
+  and so on).
+- **`_package`**: build and return the *dataset mapping* that tells Marimba which files to include, where they go, and
+  what metadata to attach.
+
+`config` is the merged collection configuration for the collection being processed. Extra `--extra key=value` arguments
+from the CLI arrive in `**kwargs`.
+
+An optional fourth method runs after the dataset directory has been assembled:
+
+```python
+def _post_package(self, dataset_dir: Path) -> set[Path]: ...
+```
+
+Override it to add or modify files in the packaged dataset (returning the set of paths you changed so the manifest can
+be updated). The default returns an empty set.
+
+### The `_package` Return Mapping
+
+`_package` returns a dict whose keys are source file paths and whose values are 3-tuples:
+
+```python
+dict[
+    Path,                                   # source file path (under data_dir)
+    tuple[
+        Path,                               # destination path, relative to the dataset data root
+        list[BaseMetadata] | None,          # metadata objects for this file, or None
+        dict[str, Any] | None,              # ancillary metadata dict, or None
+    ],
+]
+```
+
+For each file to include, map its source path to `(destination_path, [metadata], ancillary)`. Attach metadata to
+imagery; pass `None` for the metadata and ancillary slots for files that carry none (for example a sensor CSV copied
+verbatim). Marimba mints deterministic per-image UUIDs and computes SHA-256 hashes at packaging time, so you do not set
+those yourself.
+
+### Runtime Helpers
+
+Inside your lifecycle methods you have access to:
+
+- `self.config` - the pipeline-level configuration dict (from `pipeline.yml`).
+- `self.dry_run` - `True` when the command was invoked with `--dry-run`; gate all filesystem writes on `not
+  self.dry_run`.
+- `self.logger` - a standard library `logging.Logger` scoped to the pipeline; use it for the audit trail.
+- `self._metadata_class` - the metadata class fixed in the constructor.
+
+---
+
+## Metadata Classes
+
+Metadata classes adapt a metadata standard to Marimba's packaging machinery. They live under `marimba.core.schemas` and
+all inherit from `BaseMetadata`.
+
+### `BaseMetadata`
+
+`BaseMetadata` (in `marimba.core.schemas.base`) is an abstract class defining the interface Marimba relies on when it
+writes dataset metadata, embeds EXIF and builds the summary and map. Concrete subclasses expose the following read-only
+properties, each returning the value or `None` where absent:
+
+```python
+@property
+def datetime(self) -> datetime | None: ...
+@property
+def latitude(self) -> float | None: ...
+@property
+def longitude(self) -> float | None: ...
+@property
+def altitude(self) -> float | None: ...
+@property
+def context(self) -> str | None: ...
+@property
+def license(self) -> str | None: ...
+@property
+def creators(self) -> list[str]: ...
+@property
+def hash_sha256(self) -> str | None: ...   # settable; Marimba populates it at packaging time
+```
+
+It also declares two static methods Marimba calls during packaging - `create_dataset_metadata(...)` (writes the
+dataset-level metadata file) and `process_files(...)` (embeds per-file metadata such as EXIF). You rarely call these
+directly; they are invoked by `DatasetWrapper` when packaging.
+
+### `iFDOMetadata`
+
+`iFDOMetadata` (in `marimba.core.schemas.ifdo`) is the default and most complete implementation, targeting the
+[iFDO](https://marine-imaging.com/fair/ifdos/iFDO-overview/) standard. Construct it from an `ifdo` `ImageData` object
+(or a list of them, for multi-frame video):
+
+```python
+from datetime import datetime, timezone
+
+from ifdo.models import ImageData
+from marimba.core.schemas.ifdo import iFDOMetadata
+
+image_data = ImageData(
+    image_datetime=datetime(2026, 2, 14, 3, 21, 0, tzinfo=timezone.utc),
+    image_latitude=-23.5,
+    image_longitude=152.0,
+)
+metadata = iFDOMetadata(image_data)
+```
+
+`ImageData` and its supporting types (`ImageContext`, `ImagePI`, `ImageCreator`, `ImageLicense`, and the various capture
+enumerations) come from the [`ifdo`](https://pypi.org/project/ifdo/) package. See the
+[Pipeline Implementation Guide](pipeline.md) for the full set of iFDO fields and which are required.
+
+### `DarwinCoreMetadata` and `GenericMetadata`
+
+Two further implementations are available for pipelines that emit other standards:
+
+- `DarwinCoreMetadata` (in `marimba.core.schemas.darwin`) - for [Darwin Core](https://dwc.tdwg.org/) biological
+  occurrence data.
+- `GenericMetadata` (in `marimba.core.schemas.generic`) - a flexible dictionary-backed implementation for metadata that
+  does not fit iFDO or Darwin Core.
+
+Both expose the same `BaseMetadata` property interface, so the rest of the packaging pipeline treats them uniformly.
+
+---
+
+## Standard Library
+
+`marimba.lib` provides helpers for the common image, GPS and EXIF operations pipelines perform during `_process` and
+`_package`.
+
+### `marimba.lib.image`
+
+Image manipulation built on Pillow and OpenCV. Selected functions:
+
+```python
+from marimba.lib import image
+
+# Write a thumbnail of `image` into `output_directory`; returns the thumbnail path.
+image.generate_image_thumbnail(image: Path, output_directory: Path, suffix: str = "_THUMB") -> Path
+
+# Resize to fit within a bounding box, preserving aspect ratio (writes to `destination` or in place).
+image.resize_fit(path, max_width: int = 1920, max_height: int = 1080, destination=None) -> None
+
+# Resize to exact dimensions.
+image.resize_exact(path, width, height, destination=None) -> None
+
+# Convert an image to JPEG at the given quality; returns the output path.
+image.convert_to_jpeg(path, quality: int = 95, destination=None) -> Path
+
+# Compose a grid montage from many images; returns the list of written grid image paths.
+image.create_grid_image(paths, destination, columns: int = 5, column_width: int = 300, max_height: int = 32000) -> list[Path]
+
+# Read dimensions without fully decoding.
+image.get_width_height(path) -> tuple[int, int]
+
+# Simple blur detection via variance of the Laplacian.
+image.is_blurry(path, threshold: float = 100.0) -> bool
+```
+
+Further helpers include `scale`, `crop`, `rotate_clockwise`, `turn_clockwise`, `flip_vertical`, `flip_horizontal`,
+`sharpen`, `gaussian_blur`, `apply_clahe`, `get_shannon_entropy` and `get_average_image_color`.
+
+### `marimba.lib.gps`
+
+Coordinate conversion and extraction:
+
+```python
+from marimba.lib import gps
+
+gps.convert_gps_coordinate_to_degrees(...)                 # DMS components -> decimal degrees
+gps.convert_degrees_to_gps_coordinate(degrees: float) -> tuple[int, int, int]   # decimal -> (deg, min, sec)
+gps.parse_location_from_metadata(metadata) -> tuple[float | None, float | None]  # (lat, lon) from an EXIF dict
+gps.read_exif_location(path) -> tuple[float | None, float | None]                # (lat, lon) from a file
+```
+
+### `marimba.lib.exif`
+
+Reading EXIF, with a batched session for efficiency over many files:
+
+```python
+from marimba.lib import exif
+
+tags = exif.get_dict(path)      # read all EXIF tags for one file as a dict
+
+with exif.session() as et:      # batched ExifTool session for many files
+    ...
+```
+
+---
+
+## A Complete Worked Example
+
+The following is a minimal but complete pipeline. It imports JPEG images, generates thumbnails, and packages each image
+with iFDO metadata. It is the pattern a real pipeline follows; the [Pipeline Implementation Guide](pipeline.md) expands
+each step.
+
+```python
+from datetime import datetime, timezone
+from pathlib import Path
+from shutil import copy2
+from typing import Any
+
+from ifdo.models import ImageContext, ImageData
+
+from marimba.core.pipeline import BasePipeline
+from marimba.core.schemas.base import BaseMetadata
+from marimba.core.schemas.ifdo import iFDOMetadata
+from marimba.lib import image
+
+
+class ExamplePipeline(BasePipeline):
+    """A minimal pipeline that imports JPEGs and packages them with iFDO metadata."""
+
+    def __init__(
+        self,
+        root_path: str | Path,
+        config: dict[str, Any] | None = None,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(root_path, config, dry_run=dry_run, metadata_class=iFDOMetadata)
+
+    @staticmethod
+    def get_pipeline_config_schema() -> dict[str, Any]:
+        return {"platform_id": "CAM01"}
+
+    @staticmethod
+    def get_collection_config_schema() -> dict[str, Any]:
+        return {}
+
+    def _import(self, data_dir: Path, source_path: Path, config: dict[str, Any], **kwargs: Any) -> None:
+        for source_file in source_path.rglob("*"):
+            if source_file.is_file() and source_file.suffix.lower() == ".jpg":
+                if not self.dry_run:
+                    copy2(source_file, data_dir)
+                self.logger.debug(f"Imported {source_file} -> {data_dir}")
+
+    def _process(self, data_dir: Path, config: dict[str, Any], **kwargs: Any) -> None:
+        thumbs = data_dir / "thumbnails"
+        if not self.dry_run:
+            thumbs.mkdir(exist_ok=True)
+        for jpg in data_dir.iterdir():
+            if jpg.is_file() and jpg.suffix.lower() == ".jpg":
+                if not self.dry_run:
+                    image.generate_image_thumbnail(jpg, thumbs)
+                self.logger.debug(f"Thumbnailed {jpg.name}")
+
+    def _package(
+        self,
+        data_dir: Path,
+        config: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]]:
+        platform_id = self.config.get("platform_id", "CAM01")
+        data_mapping: dict[Path, tuple[Path, list[BaseMetadata] | None, dict[str, Any] | None]] = {}
+
+        for jpg in data_dir.iterdir():
+            if not (jpg.is_file() and jpg.suffix.lower() == ".jpg"):
+                continue
+            image_data = ImageData(
+                image_datetime=datetime.now(tz=timezone.utc),
+                image_platform=ImageContext(name=platform_id),
+            )
+            metadata = self._metadata_class(image_data)
+            output_path = Path("images") / jpg.name
+            data_mapping[jpg] = (output_path, [metadata], None)
+
+        return data_mapping
+```
+
+Publish this class as a Git repository (a single `*.pipeline.py` file plus a `requirements.txt`) and install it with
+`marimba new pipeline`, then run `marimba import`, `marimba process` and `marimba package` as shown in the
+[Overview and CLI Usage Guide](overview.md).
+
+---
+
+## Driving Marimba Programmatically
+
+The wrapper classes let you run the same operations from Python. They live under `marimba.core.wrappers`.
+
+### `ProjectWrapper`
+
+`ProjectWrapper` manages a project directory and orchestrates the import/process/package lifecycle.
+
+```python
+from marimba.core.wrappers.project import ProjectWrapper
+
+# Create a new project, or load an existing one
+project = ProjectWrapper.create("/data/projects/example")   # classmethod; returns a ProjectWrapper
+project = ProjectWrapper("/data/projects/example")           # load existing
+```
+
+Key methods:
+
+```python
+# Install a pipeline from a Git URL (accept_defaults skips config prompts)
+project.create_pipeline(name: str, url: str, config: dict[str, Any], *, accept_defaults: bool = False) -> PipelineWrapper
+
+# Import source data into a collection
+project.run_import(
+    collection_name: str,
+    source_paths: list[Path],
+    pipeline_names: list[str],
+    extra_args: list[str] | None = None,
+    operation: Operation = Operation.copy,
+    max_workers: int | None = None,
+) -> None
+
+# Process collections with pipelines
+project.run_process(
+    collection_names: list[str],
+    pipeline_names: list[str],
+    extra_args: list[str] | None = None,
+    max_workers: int | None = None,
+    **kwargs: Any,
+) -> None
+
+# Build the dataset mapping across collections and pipelines
+project.compose(
+    dataset_name: str,
+    collection_names: list[str],
+    pipeline_names: list[str],
+    extra_args: list[str] | None = None,
+    max_workers: int | None = None,
+    **kwargs: Any,
+) -> dict   # the composed dataset mapping
+
+# Package a composed mapping into a dataset
+project.create_dataset(
+    dataset_name: str,
+    dataset_mapping: dict,
+    metadata_mapping_processor_decorator: list,
+    post_package_processors: list,
+    operation: Operation = Operation.copy,
+    version: str | None = "1.0",
+    contact_name: str | None = None,
+    contact_email: str | None = None,
+    zoom: int | None = None,
+    max_workers: int | None = None,
+    *,
+    force: bool = False,
+    exif_chunk_size: int | None = None,
+    allow_destination_collisions: bool = False,
+) -> DatasetWrapper
+
+# Distribute a packaged dataset to a configured target
+project.distribute(dataset_name: str, target_name: str, validate: bool) -> None
+```
+
+`ProjectWrapper` also exposes `create_collection`, `create_target`, `install_pipelines`, `update_pipelines`, the
+`delete_*` methods, and read-only properties `root_dir`, `name`, `pipeline_wrappers`, `collection_wrappers`,
+`dataset_wrappers`, `target_wrappers` and `dry_run`. `get_pipeline_post_processors(pipeline_names)` returns the
+post-package processors to pass to `create_dataset`.
+
+A programmatic package mirrors what the CLI does - compose the mapping, then create the dataset:
+
+```python
+pipeline_names = list(project.pipeline_wrappers.keys())
+collection_names = list(project.collection_wrappers.keys())
+
+mapping = project.compose("my-dataset", collection_names, pipeline_names)
+dataset = project.create_dataset(
+    "my-dataset",
+    mapping,
+    metadata_mapping_processor_decorator=[],
+    post_package_processors=project.get_pipeline_post_processors(pipeline_names),
+    contact_name="Your Name",
+    contact_email="you@example.org",
+)
+```
+
+### `PipelineWrapper`
+
+Manages a single installed pipeline directory: cloning/installing the repository, loading and saving its configuration,
+and instantiating the pipeline class.
+
+```python
+from marimba.core.wrappers.pipeline import PipelineWrapper
+
+pw = PipelineWrapper("/data/projects/example/pipelines/my-pipeline")
+pw.load_config() -> dict[str, Any]
+pw.get_instance() -> BasePipeline | None    # instantiate the pipeline class
+pw.install() -> None                         # install its requirements
+pw.update() -> None                          # git pull the repository
+```
+
+### `CollectionWrapper`
+
+Manages a collection directory and its per-pipeline data directories.
+
+```python
+from marimba.core.wrappers.collection import CollectionWrapper
+
+cw = CollectionWrapper("/data/projects/example/collections/dive-001")
+cw.load_config() -> dict[str, Any]
+cw.get_pipeline_data_dir(pipeline_name: str) -> Path
+```
+
+### `DatasetWrapper`
+
+Represents a packaged dataset directory. It is normally produced by `ProjectWrapper.create_dataset`, but can be opened
+directly to validate an existing dataset against its manifest:
+
+```python
+from marimba.core.wrappers.dataset import DatasetWrapper
+
+dw = DatasetWrapper("/data/projects/example/datasets/my-dataset")
+dw.validate()   # raises DatasetWrapper.ManifestError on a mismatch
+```
+
+Useful read-only properties include `root_dir`, `name`, `data_dir`, `manifest_path`, `version`, `contact_name`,
+`contact_email` and `image_set_uuid`.
+
+### `DistributionTargetWrapper`
+
+Represents a distribution target configuration and resolves the concrete target implementation (for example S3):
+
+```python
+from marimba.core.wrappers.target import DistributionTargetWrapper
+
+tw = DistributionTargetWrapper("/data/projects/example/targets/s3-public.yml")
+target = tw.get_instance()   # the concrete DistributionTargetBase implementation, or None
+```
+
+---
+
+## Exceptions
+
+All Marimba errors derive from a common base class, `MarimbaError`, importable from `marimba.core`:
+
+```python
+from marimba.core import MarimbaError
+```
+
+Wrapper-specific errors are defined as nested classes on the wrapper that raises them, so catch them via the wrapper.
+For example, `ProjectWrapper` defines `NoSuchPipelineError`, `NoSuchCollectionError`, `NoSuchDatasetError`,
+`NoSuchTargetError`, `InvalidNameError`, `CreatePipelineError`, `CreateCollectionError`, `CompositionError`,
+`InvalidStructureError` and others; `DatasetWrapper` defines `ManifestError`, `InvalidStructureError` and
+`InvalidDatasetMappingError`. Because they all inherit from `MarimbaError`, you can catch broadly or narrowly:
+
+```python
+try:
+    project.run_process(collection_names, pipeline_names)
+except ProjectWrapper.NoSuchCollectionError:
+    ...                       # handle a specific failure
+except MarimbaError:
+    ...                       # handle any Marimba error
+```
+
+---
+
+## Logging
+
+Marimba uses the standard library `logging` module throughout, accessed via a helper:
+
+```python
+from marimba.core.utils.log import get_logger
+
+logger = get_logger(__name__)
+logger.info("Processing complete")
+```
+
+Inside a pipeline, prefer the ready-made `self.logger` rather than creating your own. Keep library code free of
+`print(...)`; the logger is the audit trail that is captured into `project.log` and the per-pipeline logs, and copied
+into every packaged dataset.
+
+For more on the pipeline lifecycle these APIs support, see the [Pipeline Implementation Guide](pipeline.md). For the
+command-line equivalents, see the [Overview and CLI Usage Guide](overview.md) and the
+[CLI Scripting Guide](cli.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,9 +1,249 @@
-# Coming Soon
+# Marimba CLI Scripting Guide
 
-This section is under development and will be available shortly.
+This guide shows how to drive Marimba non-interactively so that whole processing workflows can be captured in a script
+and reproduced. It focuses on the patterns that make automation reliable - suppressing interactive prompts, handling
+exit codes, controlling logging and parallelism, and previewing with dry runs - rather than repeating the per-command
+option reference. For the full list of commands and options, see the
+[Overview and CLI Usage Guide](overview.md); for writing the pipelines these commands drive, see the
+[Pipeline Implementation Guide](pipeline.md).
 
 ---
 
-In the meantime, perhaps you might enjoy some [Keiko Abe playing the marimba](https://open.spotify.com/artist/7Gbxp2rkJ1RpBoI86e9UAF?si=xa-RdgcCSWyDIoxymxIj5A).
+## Table of Contents
 
-*Note: Keiko Abe is a renowned Japanese marimba player and composer who helped establish the marimba as a respected concert instrument.*
+1. [Running Marimba Non-Interactively](#running-marimba-non-interactively)
+2. [Exit Codes and Error Handling](#exit-codes-and-error-handling)
+3. [Logging in Scripts](#logging-in-scripts)
+4. [A Complete Workflow Script](#a-complete-workflow-script)
+5. [Batching Over Collections](#batching-over-collections)
+6. [Previewing with Dry Runs](#previewing-with-dry-runs)
+7. [Controlling Parallelism](#controlling-parallelism)
+8. [Running on HPC and Shared Systems](#running-on-hpc-and-shared-systems)
+9. [Best Practices](#best-practices)
+
+---
+
+## Running Marimba Non-Interactively
+
+By default `marimba new pipeline`, `marimba new collection` and `marimba import` prompt for pipeline- and
+collection-level configuration. Scripts must suppress those prompts, using one or both of:
+
+- **`--config '{"key": "value"}'`**: supply configuration values as a JSON string. They are merged with the pipeline's
+  schema defaults.
+- **`--accept-defaults` (`-y`)**: accept every remaining default without prompting.
+
+Supply `--config` for the values you care about and add `--accept-defaults` to accept the rest, so no prompt can block
+the script:
+
+```bash
+marimba import dive-001 /data/raw/dive-001 \
+  --config '{"site_id": "GBR-001"}' \
+  --accept-defaults
+```
+
+For configuration that is awkward to inline, build the JSON in a file and pass its contents:
+
+```bash
+cat > /tmp/collection-config.json <<'EOF'
+{
+  "site_id": "GBR-001",
+  "deployment_date": "2026-02-14"
+}
+EOF
+
+marimba import dive-001 /data/raw/dive-001 \
+  --config "$(cat /tmp/collection-config.json)" \
+  --accept-defaults
+```
+
+---
+
+## Exit Codes and Error Handling
+
+Marimba commands exit `0` on success and `1` on failure, so standard shell error handling works. Start scripts with
+`set -euo pipefail` so a failed step aborts the run instead of silently continuing:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+marimba process
+marimba package my-dataset --contact-name "Your Name" --contact-email "you@example.org"
+```
+
+To react to a failure rather than abort, test the exit code explicitly:
+
+```bash
+if ! marimba process --collection-name dive-001; then
+  echo "Processing failed for dive-001" >&2
+  exit 1
+fi
+```
+
+---
+
+## Logging in Scripts
+
+The global `--level` flag controls terminal verbosity and must appear before the subcommand. Use `DEBUG` while
+developing a script and `INFO` for routine runs; the default is `WARNING`.
+
+```bash
+marimba --level DEBUG process
+```
+
+Marimba also writes a persistent audit trail to `project.log` at the project root (and per-pipeline logs under
+`pipelines/<name>/`), independent of `--level`. Timestamp your script's own progress messages to correlate them with the
+log:
+
+```bash
+echo "[$(date -Is)] starting process"
+marimba --level INFO process
+echo "[$(date -Is)] process complete"
+```
+
+---
+
+## A Complete Workflow Script
+
+A self-contained script that creates a project, installs a pipeline, imports and processes data, and packages a dataset.
+It is idempotent enough to re-run by pointing `--project-dir` at a fresh location.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="/data/projects/marine-survey-2026"
+PIPELINE_URL="https://github.com/org/benthic-camera-pipeline.git"
+SOURCE_DATA="/data/raw/marine-survey-2026"
+
+# 1. Create the project (skip if it already exists)
+if [[ ! -d "$PROJECT_DIR" ]]; then
+  marimba new project "$PROJECT_DIR"
+fi
+
+# 2. Install the pipeline, accepting default pipeline configuration
+marimba new pipeline benthic-camera "$PIPELINE_URL" \
+  --project-dir "$PROJECT_DIR" \
+  --config '{"platform_id": "CAM01"}' \
+  --accept-defaults
+
+# 3. Import the source data into a collection
+marimba import survey-2026 "$SOURCE_DATA" \
+  --project-dir "$PROJECT_DIR" \
+  --operation link \
+  --config '{"site_id": "GBR-001"}' \
+  --accept-defaults
+
+# 4. Process and package
+marimba --level INFO process --project-dir "$PROJECT_DIR"
+marimba --level INFO package marine-survey-2026 \
+  --project-dir "$PROJECT_DIR" \
+  --version 1.0 \
+  --contact-name "Dr Marine Scientist" \
+  --contact-email "scientist@institution.org"
+```
+
+---
+
+## Batching Over Collections
+
+Loop to import several collections from a directory of sources, deriving each collection name from its directory:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_ROOT="/data/raw/2026"
+
+for src in "$SOURCE_ROOT"/*/; do
+  collection="$(basename "$src")"
+  marimba import "$collection" "$src" --accept-defaults
+done
+
+# Process and package everything at once
+marimba process
+marimba package survey-2026 --contact-name "Your Name" --contact-email "you@example.org"
+```
+
+Import creates each collection on demand, so a single `marimba process` afterwards covers every collection the loop
+imported. To process each collection as it is imported instead, move a `marimba process --collection-name
+"$collection"` call inside the loop.
+
+---
+
+## Previewing with Dry Runs
+
+Every mutating command supports `--dry-run`, which logs what would happen (prefixed with `DRY_RUN -`) without touching
+files, while still running structural and safety validation. A useful scripting pattern is to preview, then run for real
+once the preview looks right:
+
+```bash
+# Preview
+marimba package survey-2026 --contact-name "Your Name" --contact-email "you@example.org" --dry-run
+
+# Run for real
+marimba package survey-2026 --contact-name "Your Name" --contact-email "you@example.org"
+```
+
+Because a dry run exits non-zero if validation fails, you can gate the real run on a successful preview:
+
+```bash
+marimba package survey-2026 --contact-name "Your Name" --contact-email "you@example.org" --dry-run \
+  && marimba package survey-2026 --contact-name "Your Name" --contact-email "you@example.org"
+```
+
+---
+
+## Controlling Parallelism
+
+Import, process and package parallelise across collections using all available CPU cores by default. On shared or
+memory-constrained machines, cap concurrency with `--max-workers` so Marimba does not contend with other work:
+
+```bash
+marimba process --max-workers 4
+marimba package survey-2026 --max-workers 4 \
+  --contact-name "Your Name" --contact-email "you@example.org"
+```
+
+Marimba does not read any environment variables to configure runtime behaviour - parallelism is controlled entirely by
+`--max-workers`.
+
+---
+
+## Running on HPC and Shared Systems
+
+On a cluster, make the [ExifTool](https://exiftool.org/) dependency available before invoking Marimba - for example via
+an environment module if your site provides one - and match `--max-workers` to the cores your job requested rather than
+letting Marimba grab every core on the node:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Make ExifTool available (site-specific; only if provided as a module)
+module load exiftool 2>/dev/null || true
+
+# Match the scheduler's core allocation
+WORKERS="${SLURM_CPUS_PER_TASK:-4}"
+
+marimba --level INFO process --project-dir "$PROJECT_DIR" --max-workers "$WORKERS"
+```
+
+Only ExifTool is validated at startup; the FFmpeg libraries used for video are provided by the PyAV Python package, so
+you do not need to load a separate `ffmpeg` module. When importing large volumes, prefer `--operation link` to avoid
+duplicating data on scratch storage.
+
+---
+
+## Best Practices
+
+1. **Fail fast**: begin scripts with `set -euo pipefail` so a failed step stops the run.
+2. **Suppress prompts**: always pair `--config` with `--accept-defaults` in unattended runs.
+3. **Define paths once**: hoist project, source and pipeline paths into variables at the top of the script.
+4. **Preview first**: run mutating commands with `--dry-run` before the real invocation, especially with
+   `--operation move`.
+5. **Prefer links for large data**: `--operation link` avoids copying large source trees.
+6. **Keep the audit trail**: archive `project.log` alongside the dataset; it records exactly what each run did.
+
+For the full command and option reference, see the [Overview and CLI Usage Guide](overview.md). To integrate Marimba
+into Python applications rather than shell scripts, see the [API Reference](api.md).

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -33,7 +33,7 @@ git clone https://github.com/csiro-fair/marimba.git
 The architecture of the Marimba project is organised according to best practices outlined in the following resources:
 
 * [The optimal python project structure](https://awaywithideas.com/the-optimal-python-project-structure/)
-* [Structuring Your Project — The Hitchhiker's Guide to Python](https://docs.python-guide.org/writing/structure/)
+* [Structuring Your Project - The Hitchhiker's Guide to Python](https://docs.python-guide.org/writing/structure/)
 
 The repository structure is as follows:
 
@@ -81,7 +81,9 @@ Before setting up the Python environment, you'll need to install system-level de
 ### Required System Tools
 
 **ExifTool**: Required for EXIF metadata reading and writing
-**FFmpeg**: Required for video processing functionality
+
+Video processing does not require a separate FFmpeg installation: Marimba uses the PyAV Python package, which bundles or
+links the FFmpeg libraries it needs.
 
 ### Installation Instructions
 
@@ -213,7 +215,7 @@ python -m build
 This command will generate a `dist` directory containing the built wheel package. This package can then be installed on other systems:
 
 ```bash
-uv pip install dist/marimba-1.0.0-py3-none-any.whl
+uv pip install dist/marimba-1.2.0-py3-none-any.whl
 ```
 
 <p align="right">(<a href="#marimba-development-environment-setup-guide-top">back to top</a>)</p>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,9 +1,531 @@
-# Coming Soon
+# Marimba Overview and CLI Usage Guide
 
-This section is under development and will be available shortly.
+Marimba is a Python framework for structuring, managing and processing
+[FAIR (Findable, Accessible, Interoperable, Reusable)](https://ardc.edu.au/resource/fair-data/) scientific image
+datasets. This guide gives you an architectural understanding of how Marimba is organised and a complete reference for
+the command-line interface used to drive data processing workflows. If you want to build your own processing logic, read
+the [Pipeline Implementation Guide](pipeline.md) next; if you want to script or automate Marimba, see the
+[CLI Scripting Guide](cli.md); and if you want to drive Marimba programmatically from Python, see the
+[API Reference](api.md).
 
 ---
 
-In the meantime, perhaps you might enjoy some [Keiko Abe playing the marimba](https://open.spotify.com/artist/7Gbxp2rkJ1RpBoI86e9UAF?si=xa-RdgcCSWyDIoxymxIj5A).
+## Table of Contents
 
-*Note: Keiko Abe is a renowned Japanese marimba player and composer who helped establish the marimba as a respected concert instrument.*
+1. [Architecture Overview](#architecture-overview)
+   - [Core Concepts](#core-concepts)
+   - [Project Directory Structure](#project-directory-structure)
+   - [Processing Workflow](#processing-workflow)
+2. [Getting Started](#getting-started)
+   - [Prerequisites](#prerequisites)
+   - [Installation](#installation)
+   - [Creating Your First Project](#creating-your-first-project)
+3. [CLI Command Reference](#cli-command-reference)
+   - [Global Options](#global-options)
+   - [`marimba new`](#marimba-new)
+   - [`marimba import`](#marimba-import)
+   - [`marimba process`](#marimba-process)
+   - [`marimba package`](#marimba-package)
+   - [`marimba distribute`](#marimba-distribute)
+   - [`marimba update`](#marimba-update)
+   - [`marimba install`](#marimba-install)
+   - [`marimba delete`](#marimba-delete)
+   - [`marimba version`](#marimba-version)
+4. [Configuration and Metadata](#configuration-and-metadata)
+   - [Pipeline Configuration](#pipeline-configuration)
+   - [Collection Configuration](#collection-configuration)
+   - [Non-Interactive Configuration](#non-interactive-configuration)
+   - [Extra Pass-Through Arguments](#extra-pass-through-arguments)
+5. [Common Options](#common-options)
+   - [Dry-Run Mode](#dry-run-mode)
+   - [Parallel Processing](#parallel-processing)
+   - [Targeting Pipelines and Collections](#targeting-pipelines-and-collections)
+6. [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture Overview
+
+### Core Concepts
+
+Marimba is organised around five concepts that together take raw instrument data through to a packaged, distributable
+dataset.
+
+- **Project**: the top-level workspace. A project is a directory with a standardised layout that holds your installed
+  pipelines, imported collections, packaged datasets and distribution targets, along with project-wide configuration and
+  logs. Every other concept lives inside a project.
+- **Pipeline**: the processing implementation for a specific instrument or multi-instrument system. A pipeline is an
+  external Git repository containing a Python class that inherits from `BasePipeline` and implements the import, process
+  and package steps. Pipelines are installed into a project and are versioned independently of it. See the
+  [Pipeline Implementation Guide](pipeline.md) for how to write one.
+- **Collection**: a discrete import of data into the project. Each collection is an isolated unit that pipelines
+  process independently and in parallel. Collections carry their own configuration (for example a deployment or site
+  identifier) and hold a per-pipeline data directory.
+- **Dataset**: the FAIR-compliant output. Packaging assembles processed collection data into a dataset directory
+  complete with metadata (iFDO by default), a file-integrity manifest, a provenance record, a human-readable summary and
+  a geospatial map.
+- **Target**: a distribution endpoint (for example an S3 bucket) that a packaged dataset can be uploaded to.
+
+### Project Directory Structure
+
+`marimba new project` creates a directory with the following layout. Sub-directories are populated as you install
+pipelines, import collections and package datasets.
+
+```plaintext
+my-project/
+├── collections/              # Imported data collections
+│   └── my-collection/
+│       ├── collection.yml    # Collection configuration
+│       └── <pipeline-name>/  # Per-pipeline data directory
+├── pipelines/                # Installed pipeline repositories
+│   └── my-pipeline/
+│       ├── pipeline.yml      # Pipeline configuration
+│       ├── repo/             # Cloned pipeline Git repository
+│       └── <pipeline>.log    # Pipeline log
+├── datasets/                 # Packaged FAIR datasets
+│   └── my-dataset/
+│       ├── data/             # Dataset files, organised by pipeline
+│       │   └── <pipeline>/   # Destination layout returned by the pipeline
+│       ├── logs/             # Copied project and pipeline logs
+│       ├── pipelines/        # Copied pipeline source
+│       ├── ifdo.json         # iFDO metadata (JSON by default; YAML with --metadata-output yaml)
+│       ├── summary.md        # Human-readable summary
+│       ├── map.png           # Geospatial overview map (when imagery is geolocated)
+│       ├── manifest.txt      # File-integrity manifest
+│       └── provenance.json   # PROV-O provenance record
+├── targets/                  # Distribution target configurations
+│   └── my-target.yml
+└── project.log               # Project-level log
+```
+
+### Processing Workflow
+
+A typical Marimba workflow proceeds through four stages, each backed by a CLI command:
+
+1. **Import** (`marimba import`) - bring raw data into a collection, optionally by copy, move or link.
+2. **Process** (`marimba process`) - run each pipeline's processing logic over its collection data in parallel
+   sandboxes.
+3. **Package** (`marimba package`) - assemble processed data into a FAIR dataset with metadata, manifest and provenance.
+4. **Distribute** (`marimba distribute`) - upload a packaged dataset to a configured target.
+
+Project, pipeline and collection scaffolding is created up front with `marimba new`, and pipelines are kept current with
+`marimba update` and `marimba install`.
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- **Python 3.12, 3.13 or 3.14** (`requires-python = ">=3.12,<3.15"`).
+- **[ExifTool](https://exiftool.org/)**: required for reading and embedding image metadata. It is validated at the
+  start of `import`, `process` and `package`; those commands exit with an actionable error if it is not on your `PATH`.
+- **Git**: required for installing and updating pipelines, which are Git repositories.
+- **FFmpeg libraries**: required only when a pipeline processes video. Marimba uses [PyAV](https://pyav.org/), which
+  bundles or links the FFmpeg libraries; you do not need the standalone `ffmpeg` command-line tool on your `PATH`.
+
+For a full walk-through of setting up a development environment (including installing ExifTool on each platform), see
+the [Environment Setup Guide](environment.md).
+
+### Installation
+
+Install the released package from PyPI:
+
+```bash
+pip install marimba
+```
+
+Verify the installation:
+
+```bash
+marimba version
+marimba --help
+```
+
+To work on Marimba itself, clone the repository and use [uv](https://docs.astral.sh/uv/):
+
+```bash
+git clone https://github.com/csiro-fair/marimba.git
+cd marimba
+uv sync --dev
+uv run marimba --help
+```
+
+### Creating Your First Project
+
+The following sequence creates a project, installs a pipeline, imports data, processes it and packages a dataset.
+Replace the pipeline URL and data path with your own.
+
+```bash
+# 1. Create and enter a new project
+marimba new project my-first-project
+cd my-first-project
+
+# 2. Install a pipeline from its Git repository
+marimba new pipeline my-pipeline https://github.com/org/my-pipeline.git
+
+# 3. Import raw data into a collection
+marimba import my-collection /path/to/raw/data
+
+# 4. Process all collections with all pipelines
+marimba process
+
+# 5. Package the processed data into a FAIR dataset
+marimba package my-dataset \
+  --contact-name "Your Name" \
+  --contact-email "you@example.org"
+```
+
+---
+
+## CLI Command Reference
+
+All commands are invoked as `marimba <command>`. Run `marimba <command> --help` (or `marimba <command> <subcommand>
+--help`) at any time for the authoritative, version-specific option list. Every command that mutates state supports
+`--dry-run`; see [Dry-Run Mode](#dry-run-mode).
+
+Commands that operate on an existing project locate the project root automatically by searching the current working
+directory and its parents. Pass `--project-dir PATH` to point at a specific project instead.
+
+### Global Options
+
+These options apply to the top-level `marimba` command and must appear before the subcommand.
+
+| Option | Description |
+| --- | --- |
+| `--level [DEBUG\|INFO\|WARNING\|ERROR]` | Logging verbosity written to the terminal. Default: `WARNING`. |
+| `--version` | Show the Marimba version and exit. |
+| `--install-completion` | Install shell completion for the current shell. |
+| `--show-completion` | Print shell completion so you can copy or customise it. |
+| `--help` | Show help and exit. |
+
+```bash
+# Raise verbosity for a single command
+marimba --level INFO process
+```
+
+### `marimba new`
+
+Create a new project, pipeline, collection or target.
+
+#### `marimba new project PROJECT_DIR`
+
+Creates a new project at `PROJECT_DIR`.
+
+```bash
+marimba new project /data/marine-survey-2026
+```
+
+#### `marimba new pipeline PIPELINE_NAME URL`
+
+Clones the pipeline Git repository at `URL`, installs it under the given `PIPELINE_NAME`, and prompts for any
+pipeline-level configuration the pipeline declares.
+
+| Option | Description |
+| --- | --- |
+| `--config TEXT` | Custom configuration as a JSON string, merged with the prompted configuration. |
+| `--accept-defaults`, `-y` | Accept all default configuration values without prompting. |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+marimba new pipeline benthic-camera https://github.com/org/benthic-camera-pipeline.git \
+  --config '{"platform_id": "CAM01"}'
+```
+
+#### `marimba new collection COLLECTION_NAME [PARENT_COLLECTION_NAME]`
+
+Creates an empty collection and prompts for its configuration. An optional parent collection name lets the new
+collection inherit configuration; if omitted, the most recently modified collection is used as the parent.
+
+| Option | Description |
+| --- | --- |
+| `--config TEXT` | Custom configuration as a JSON string, merged with the prompted configuration. |
+| `--accept-defaults`, `-y` | Accept all default configuration values without prompting. |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+marimba new collection dive-001 --config '{"site_id": "GBR-001"}'
+```
+
+> In most workflows you do not need `marimba new collection`: `marimba import` creates the target collection on demand.
+> Use it when you want to create and configure a collection before importing into it.
+
+#### `marimba new target TARGET_NAME`
+
+Creates a distribution target and prompts for its type and connection details (for example an S3 bucket, endpoint and
+credentials).
+
+| Option | Description |
+| --- | --- |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+marimba new target s3-public
+```
+
+### `marimba import`
+
+```
+marimba import COLLECTION_NAME SOURCE_PATHS...
+```
+
+Imports one or more source files or directories into a collection, creating the collection if it does not yet exist.
+Each installed pipeline's `_import` logic decides how the source data is brought in.
+
+| Argument | Description |
+| --- | --- |
+| `COLLECTION_NAME` | Target collection name. |
+| `SOURCE_PATHS...` | One or more source files or directories to import. |
+
+| Option | Description |
+| --- | --- |
+| `--parent-collection-name TEXT` | Parent collection to inherit configuration from. Defaults to the last collection. |
+| `--pipeline-name TEXT` | Limit the import to specific pipelines (repeatable). Defaults to all pipelines. |
+| `--operation [copy\|move\|link]` | How source files are brought in. Default: `copy`. |
+| `--overwrite` / `--no-overwrite` | Overwrite an existing collection of the same name. Default: `--no-overwrite`. |
+| `--config TEXT` | Custom collection configuration as a JSON string. |
+| `--accept-defaults`, `-y` | Accept all default configuration values without prompting. |
+| `--extra TEXT` | Extra key-value pass-through argument (repeatable). |
+| `--dry-run` / `--no-dry-run` | Preview without changing files. Default: `--no-dry-run`. |
+| `--max-workers INTEGER` | Maximum worker processes. Default: all available CPU cores. |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+# Import a directory, linking files instead of copying
+marimba import dive-001 /media/sd-card/ --operation link
+
+# Import from multiple sources into one collection
+marimba import combined /data/source-a /data/source-b /data/source-c
+```
+
+### `marimba process`
+
+```
+marimba process
+```
+
+Runs each pipeline's `_process` logic over its collection data. With no targeting options, all collections are processed
+by all pipelines, in parallel.
+
+| Option | Description |
+| --- | --- |
+| `--collection-name TEXT` | Limit to specific collections (repeatable). Defaults to all collections. |
+| `--pipeline-name TEXT` | Limit to specific pipelines (repeatable). Defaults to all pipelines. |
+| `--extra TEXT` | Extra key-value pass-through argument (repeatable). |
+| `--dry-run` / `--no-dry-run` | Preview without changing files. Default: `--no-dry-run`. |
+| `--max-workers INTEGER` | Maximum worker processes. Default: all available CPU cores. |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+# Process one collection with one pipeline
+marimba process --collection-name dive-001 --pipeline-name benthic-camera
+```
+
+### `marimba package`
+
+```
+marimba package DATASET_NAME
+```
+
+Assembles processed collection data into a FAIR dataset directory: it populates the data files, generates metadata
+(iFDO by default), builds a file-integrity manifest, writes a provenance record, renders a summary and, where geolocated
+imagery is present, a map.
+
+| Argument | Description |
+| --- | --- |
+| `DATASET_NAME` | Name for the packaged dataset. |
+
+| Option | Description |
+| --- | --- |
+| `--collection-name TEXT` | Limit to specific collections (repeatable). Defaults to all collections. |
+| `--pipeline-name TEXT` | Limit to specific pipelines (repeatable). Defaults to all pipelines. |
+| `--operation [copy\|move\|link]` | How dataset files are populated. Default: `copy`. |
+| `--version TEXT` | Dataset version. Default: `1.0`. |
+| `--contact-name TEXT` | Full name of the dataset contact person. |
+| `--contact-email TEXT` | Email address of the dataset contact person. |
+| `--zoom INTEGER` | Zoom level for the generated dataset map. |
+| `--metadata-output [json\|yaml]` | Metadata serialisation format. Default: `json`. |
+| `--metadata-level [project\|pipeline\|collection]` | Granularity at which metadata is grouped and written. |
+| `--exif-chunk-size INTEGER` | Chunk size for EXIF processing. Defaults to adaptive sizing. |
+| `--force` / `--no-force` | Package without prompting on hard-link warnings. Default: `--no-force`. |
+| `--allow-destination-collisions` / `--no-allow-destination-collisions` | Allow multiple sources to map to the same destination; the first source wins. Default: `--no-allow-destination-collisions`. |
+| `--extra TEXT` | Extra key-value pass-through argument (repeatable). |
+| `--dry-run` / `--no-dry-run` | Preview without changing files. Default: `--no-dry-run`. |
+| `--max-workers INTEGER` | Maximum worker processes. Default: all available CPU cores. |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+marimba package marine-survey-2026 \
+  --version 2.1 \
+  --contact-name "Dr Marine Scientist" \
+  --contact-email "scientist@institution.org" \
+  --zoom 12
+```
+
+### `marimba distribute`
+
+```
+marimba distribute DATASET_NAME TARGET_NAME
+```
+
+Uploads a packaged dataset to a configured distribution target.
+
+| Argument | Description |
+| --- | --- |
+| `DATASET_NAME` | Dataset to distribute. |
+| `TARGET_NAME` | Distribution target to upload to. |
+
+| Option | Description |
+| --- | --- |
+| `--validate` / `--no-validate` | Validate the dataset against its manifest before distribution. Default: `--validate`. |
+| `--dry-run` / `--no-dry-run` | Preview without uploading. Default: `--no-dry-run`. |
+| `--project-dir PATH` | Project root to operate on. |
+
+```bash
+marimba distribute marine-survey-2026 s3-public
+```
+
+### `marimba update`
+
+```
+marimba update
+```
+
+Pulls the latest changes for every installed pipeline repository.
+
+| Option | Description |
+| --- | --- |
+| `--project-dir PATH` | Project root to operate on. |
+
+### `marimba install`
+
+```
+marimba install
+```
+
+Installs the Python dependencies declared in each pipeline's `requirements.txt`.
+
+| Option | Description |
+| --- | --- |
+| `--project-dir PATH` | Project root to operate on. |
+
+### `marimba delete`
+
+Delete a project, pipeline, collection, dataset or target. Every `delete` subcommand accepts `--project-dir PATH` and
+`--dry-run` / `--no-dry-run` (default `--no-dry-run`).
+
+```
+marimba delete project
+marimba delete pipeline PIPELINE_NAME
+marimba delete collection COLLECTION_NAME
+marimba delete dataset DATASET_NAME
+marimba delete target TARGET_NAME
+```
+
+```bash
+# Preview what deleting a collection would remove
+marimba delete collection dive-001 --dry-run
+```
+
+### `marimba version`
+
+```
+marimba version
+```
+
+Prints the installed Marimba version. Equivalent to `marimba --version`.
+
+---
+
+## Configuration and Metadata
+
+Marimba collects configuration at two levels, both defined by the pipeline and both stored as YAML inside the project.
+The set of fields prompted for is entirely determined by the pipeline you install - see
+[Implementing Your Pipeline](pipeline.md) for how these schemas are declared.
+
+### Pipeline Configuration
+
+Pipeline-level configuration is declared by a pipeline's `get_pipeline_config_schema()` method and stored in
+`pipelines/<pipeline-name>/pipeline.yml`. It captures values that are constant across every collection the pipeline
+processes - for example a platform identifier, instrument specification or principal-investigator name. You are prompted
+for it when you run `marimba new pipeline`.
+
+### Collection Configuration
+
+Collection-level configuration is declared by a pipeline's `get_collection_config_schema()` method and stored in
+`collections/<collection-name>/collection.yml`. It captures values specific to a single import - for example a
+deployment or site identifier, or a collection date. You are prompted for it when you run `marimba import` (or
+`marimba new collection`).
+
+### Non-Interactive Configuration
+
+Both `--config` and `--accept-defaults` let you avoid interactive prompts, which is essential for scripting:
+
+- `--config '{"key": "value"}'` supplies configuration values directly as JSON; they are merged with the schema
+  defaults, and any remaining unset fields are still prompted for unless you also pass `--accept-defaults`.
+- `--accept-defaults` (`-y`) accepts every default value without prompting.
+
+See the [CLI Scripting Guide](cli.md) for non-interactive automation patterns.
+
+### Extra Pass-Through Arguments
+
+`--extra key=value` passes arbitrary key-value arguments through to the pipeline's `_import`, `_process` and `_package`
+methods, where they are available as keyword arguments. Repeat the flag to pass several:
+
+```bash
+marimba process --extra thumbnail_size=512 --extra quality=high
+```
+
+---
+
+## Common Options
+
+### Dry-Run Mode
+
+`--dry-run` is supported on every command that mutates state (`import`, `process`, `package`, `distribute` and each
+`delete` subcommand). It executes the command and prints the log of what *would* happen, prefixed with `DRY_RUN -`, but
+performs no filesystem changes. Structural and safety validation (project/collection layout checks, dataset-mapping
+checks, read-only and hard-link detection, dependency validation) still run, so a dry run surfaces problems a real run
+would hit.
+
+```bash
+marimba package test-dataset --dry-run
+```
+
+### Parallel Processing
+
+Marimba parallelises import, processing and packaging across collections. By default it uses all available CPU cores;
+cap concurrency with `--max-workers` - useful on shared or memory-constrained systems:
+
+```bash
+marimba process --max-workers 4
+```
+
+### Targeting Pipelines and Collections
+
+`--pipeline-name` and `--collection-name` are repeatable and combine to target any subset of the work. With neither, a
+command applies to all pipelines and all collections.
+
+```bash
+# Two pipelines across two collections
+marimba process \
+  --pipeline-name camera --pipeline-name sensor \
+  --collection-name dive-001 --collection-name dive-002
+```
+
+---
+
+## Troubleshooting
+
+- **`ExifTool is not available`**: install ExifTool and ensure it is on your `PATH`. See the
+  [Environment Setup Guide](environment.md).
+- **A pipeline fails to import or process**: run `marimba install` to install its dependencies, then re-run with
+  `--level DEBUG` to see per-pipeline detail.
+- **Packaging reports destination collisions**: two source files resolve to the same destination path. Fix the
+  pipeline's `_package` mapping, or pass `--allow-destination-collisions` to keep the first source.
+- **Packaging pauses on a hard-link warning**: pass `--force` to proceed non-interactively, or re-import with a
+  different `--operation`.
+- **Preview before committing**: run any mutating command with `--dry-run` first to see exactly what it would do.
+
+For developing custom pipelines, see the [Pipeline Implementation Guide](pipeline.md). For scripting and automation, see
+the [CLI Scripting Guide](cli.md). For programmatic use, see the [API Reference](api.md).

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,5 +1,3 @@
-from marimba.core.pipeline import BasePipeline
-
 # Pipeline Implementation Guide
 
 A Marimba Pipeline is the core component responsible for processing data from a specific instruments or 
@@ -219,7 +217,7 @@ There are a couple of methods to create a new Marimba Pipeline:
 
    - **Copy the repository URL:**
      - Once your repository is created, GitHub will display the repository page. Copy the URL provided under 
-     "Quick setup" — it will look something like `https://github.com/your-user-name/my-pipeline.git`
+     "Quick setup" - it will look something like `https://github.com/your-user-name/my-pipeline.git`
 
    - **Clone the new empty repository into your Marimba Project:**
      ```bash

--- a/tests/e2e/regression/README.md
+++ b/tests/e2e/regression/README.md
@@ -7,7 +7,7 @@ The load-bearing safety net against codebase-wide refactors silently breaking re
 Run it (or let the pre-push hook run it) after:
 
 - Any change in `marimba/` you suspect could affect dataset output.
-- Closing any review-cycle plan from `docs/prompts/` — it's mandated by the canonical Stage 2 closure (see [`docs/prompts/README.md`](../../../docs/prompts/README.md) §"Verification before closure").
+- Closing any review-cycle plan from `docs/prompts/` - it's mandated by the canonical Stage 2 closure (see [`docs/prompts/README.md`](../../../docs/prompts/README.md) §"Verification before closure").
 - Bumping a marimba dependency that touches an output path (Pillow / pyexiftool / staticmap / iFDO).
 - Anything else that gives you a "I think this is safe but…" feeling.
 
@@ -78,7 +78,7 @@ git push --no-verify   # use sparingly
 MARIMBA_E2E_CACHE_DIR=/path/to/shared/cache uv run pytest ...
 ```
 
-To force a refresh of either repo, delete the relevant subdir (e.g. `rm -rf .cache/marimba-e2e/data`) — the conftest will re-clone on next invocation.
+To force a refresh of either repo, delete the relevant subdir (e.g. `rm -rf .cache/marimba-e2e/data`) - the conftest will re-clone on next invocation.
 
 ## Bumping the pinned SHAs
 
@@ -93,7 +93,7 @@ When you want to track upstream changes in either repo:
 
 The tiers are ordered cheapest → most precise. If you see a failure, start at the tier that fired and work down:
 
-### Tier A — `test_tier_a_structural`
+### Tier A - `test_tier_a_structural`
 
 Asserts the dataset's shape exists. Failures point at a missing file, malformed JSON, or empty top-level artifact.
 
@@ -110,7 +110,7 @@ uv run pytest --rootdir . -c config/pytest.ini --no-cov tests/e2e/regression/tes
 ls /tmp/marimba-e2e-debug/scratch0/project/datasets/IN2018_V06/
 ```
 
-### Tier B — `test_tier_b_inventory`
+### Tier B - `test_tier_b_inventory`
 
 Asserts structural counts. Failures dump the exact category that drifted (e.g. "inventory drift at 'by_class' expected={…} actual={…}").
 
@@ -122,12 +122,12 @@ Asserts structural counts. Failures dump the exact category that drifted (e.g. "
 
 **To resolve:**
 
-1. Read the failure message — it names the specific dict that doesn't match.
-2. Decide: is this drift you intended? If yes, regenerate the goldens (see below). If no, this is the regression you set out to catch — fix the code.
+1. Read the failure message - it names the specific dict that doesn't match.
+2. Decide: is this drift you intended? If yes, regenerate the goldens (see below). If no, this is the regression you set out to catch - fix the code.
 
-### Tier C — `test_tier_c_scrubbed_manifest_byte_equality`
+### Tier C - `test_tier_c_scrubbed_manifest_byte_equality`
 
-The load-bearing tier. Asserts every dataset file's scrubbed content matches the golden, with three classes of carve-out (entries kept in the manifest for path + ordering, hash replaced with placeholder): log files under `logs/`, `map.png`, and all JPEG images. `map.png` is excluded because `staticmap` renders by fetching tiles from a remote OSM-backed server, so its bytes change over wall-clock time as upstream tile data updates — same project state produces different bytes a day later. Failures dump the first 20 differing manifest lines plus the line-count delta if any.
+The load-bearing tier. Asserts every dataset file's scrubbed content matches the golden, with three classes of carve-out (entries kept in the manifest for path + ordering, hash replaced with placeholder): log files under `logs/`, `map.png`, and all JPEG images. `map.png` is excluded because `staticmap` renders by fetching tiles from a remote OSM-backed server, so its bytes change over wall-clock time as upstream tile data updates - same project state produces different bytes a day later. Failures dump the first 20 differing manifest lines plus the line-count delta if any.
 
 JPEG content is excluded because its encoded bytes are not reproducible across CPU microarchitectures. On GitHub's mixed hosted-runner fleet a handful of borderline frames flipped between two values depending on which runner CPU executed the job: numpy's SIMD reductions and libjpeg's encoder round differently between CPU generations, and that drift shows up in the main entropy-coded scan, the embedded EXIF thumbnail's own scan, and the `image-entropy` / `image-average-color` values baked into `EXIF:UserComment`. There is no stable byte subset to hash, so JPEG content is not byte-compared at all. The image's metadata is still byte-validated through its per-image iFDO metadata (scrubbed for the same volatile fields), and Tier A/B assert each image's presence, validity, and counts.
 
@@ -147,7 +147,7 @@ JPEG content is excluded because its encoded bytes are not reproducible across C
 
 ## Rotating the goldens
 
-When a deliberate marimba or pipeline change shifts the expected output, the goldens need to be regenerated. See [`golden/README.md`](golden/README.md) for the full workflow — short version:
+When a deliberate marimba or pipeline change shifts the expected output, the goldens need to be regenerated. See [`golden/README.md`](golden/README.md) for the full workflow - short version:
 
 ```bash
 # Produce a fresh packaged dataset (the Tier C failure is expected; the run
@@ -168,7 +168,7 @@ git diff tests/e2e/regression/golden/
 
 `.github/workflows/ci-e2e.yml` runs the suite on every push to main + every PR + manual `workflow_dispatch`. Uses `actions/cache` keyed on the pinned-SHA hash of `conftest.py` so subsequent runs skip the data clone.
 
-The workflow itself doesn't gate merges — that's a GitHub repo setting under Branches → Branch protection rules → Require status checks → select `E2E regression (Ubuntu, Python 3.12)`.
+The workflow itself doesn't gate merges - that's a GitHub repo setting under Branches → Branch protection rules → Require status checks → select `E2E regression (Ubuntu, Python 3.12)`.
 
 ## Design background
 

--- a/tests/e2e/regression/golden/README.md
+++ b/tests/e2e/regression/golden/README.md
@@ -15,7 +15,7 @@ This directory holds the checked-in golden expected output that
 
 ```bash
 # 1. Run the regression suite to drive a fresh full bootstrap. The Tier C test
-#    will fail against the stale goldens — that's expected; the run still leaves
+#    will fail against the stale goldens - that's expected; the run still leaves
 #    a complete packaged dataset in pytest's tmp tree.
 uv run pytest --rootdir . -c config/pytest.ini --no-cov -m "e2e and slow" tests/e2e/regression/
 
@@ -28,7 +28,7 @@ uv run python tests/e2e/regression/golden/regenerate.py \
 #    that needs investigating, not a golden-rotation.
 git diff tests/e2e/regression/golden/
 
-# 4. Re-run the suite — it must now pass against the rotated goldens.
+# 4. Re-run the suite - it must now pass against the rotated goldens.
 uv run pytest --rootdir . -c config/pytest.ini --no-cov -m "e2e and slow" tests/e2e/regression/
 
 # 5. If the diff matches the deliberate change you made, commit the rotation
@@ -45,7 +45,7 @@ A golden rotation should be **explicit and reviewed**. Cases:
 - A data-SHA bump (`DATA_REPO_SHA`) replaces the upstream fixture.
 - An intentional change to the scrubber itself (e.g. adding a new volatile field to scrub).
 
-If a Tier C test fails in CI on a branch that didn't intend any of the above, that's a regression — fix the production code, don't rotate the golden.
+If a Tier C test fails in CI on a branch that didn't intend any of the above, that's a regression - fix the production code, don't rotate the golden.
 
 ## Scrubber correctness
 


### PR DESCRIPTION
## Summary

Completes the three README-linked guides that previously shipped as "Coming Soon" placeholders and applies a minimal accuracy pass over the existing documentation to match the v1.2.0 codebase. Adds an overview and CLI usage guide, a CLI scripting guide, and an API reference. Existing docs receive small, surgical corrections only, with no restructuring. Em-dashes are removed throughout for a consistent house style. Also makes `cjackett` the sole code owner. Historical release notes are left untouched.

## Problem

The README linked to three guides that were empty placeholders, and several existing docs had drifted from the v1.2.0 codebase (for example, listing FFmpeg as a required system dependency after it was removed).

## Solution

Wrote the three guides from scratch against current source, keeping their scopes distinct and cross-linking the pipeline guide rather than duplicating it. Applied six targeted accuracy fixes to existing docs and removed em-dashes across the set. Every CLI option was checked against `marimba --help`, every API symbol against the source, and the API guide's worked example was run end to end against the demo pipeline. Also updated `.github/CODEOWNERS` so `cjackett` is the sole code owner across all paths.

## Impact

Users and developers now have complete, accurate guidance for the CLI, scripting, and the Python API. Pull requests are no longer auto-assigned to a second code owner. Documentation and repository configuration only; no runtime changes.

## Documentation

- Added: `docs/overview.md`, `docs/cli.md`, `docs/api.md` (previously placeholders).
- Updated: `README.md`, `docs/environment.md`, `docs/pipeline.md`, `.github/SECURITY.md`, `.github/CODE_OF_CONDUCT.md`, `tests/e2e/regression/README.md`, `tests/e2e/regression/golden/README.md`, `.github/CODEOWNERS`.

## Notes to Reviewer

The API guide's worked example was verified runnable (import, process, package) against the demo dataset, producing a dataset whose manifest validates. `docs/contributing.md` and `.github/CONTRIBUTING.md` remain near-duplicates; consolidating them is an optional follow-up, not done here. Files under `docs/releases/` are intentionally untouched.
