### PR TITLE
[Chore] Make cjackett the sole code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # All files require review from a core maintainer
-* @cjackett @kevinsbarnard
+* @cjackett
 
 # CI/CD workflows
-/.github/workflows/ @cjackett @kevinsbarnard
+/.github/workflows/ @cjackett
 
 # Dependencies and build
-/pyproject.toml @cjackett @kevinsbarnard
-/uv.lock @cjackett @kevinsbarnard
+/pyproject.toml @cjackett
+/uv.lock @cjackett


### PR DESCRIPTION
## Summary

Removes `kevinsbarnard` from `.github/CODEOWNERS` so pull requests are no longer automatically assigned to him for review. `cjackett` remains the code owner for all paths, including CI workflows and dependency manifests.

## Problem

The `* @cjackett @kevinsbarnard` rule caused GitHub to auto-request Kevin as a reviewer on every PR (the author is skipped, so his co-owner entry was always requested). This was not the desired review-assignment behaviour.

## Solution

Drop `@kevinsbarnard` from every CODEOWNERS rule, leaving `@cjackett` as the sole code owner across all paths.

## Impact

New PRs will no longer auto-request Kevin. With `cjackett` as the only owner, PRs he authors get no automatic code-owner request; PRs from others will request `cjackett`. No code or runtime behaviour changes.

## Documentation

- Modified: `.github/CODEOWNERS`.