### PR TITLE
Make lint config and logging calls ruff 0.16 clean

### DIFF
--- a/config/ruff.toml
+++ b/config/ruff.toml
@@ -29,6 +29,7 @@ lint.pydocstyle.convention = "google"
 # Ignore specific rules with explanations
 lint.ignore = [
     "B008",    # Do not perform function calls in argument defaults
+    "CPY001",  # Missing copyright notice at top of file: licensing is declared once in LICENSE, not per-file
     "D104",    # Missing docstring in public package
     "D200",    # One-line docstring should fit on one line with quotes
     "D203",    # 1 blank line required before class docstring
@@ -39,6 +40,7 @@ lint.ignore = [
     "FIX002",  # Line contains TODO
     "G004",    # Logging statement uses f-string
     "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments: positional-only variant of the PLR0913 ignore above
     "S603",    # `subprocess` call: check for execution of untrusted input
     "TD003",   # Missing issue link on TODO
     "UP042",   # Class inherits from str+Enum: keep over StrEnum, whose __str__ differs and changes typer CLI / serialised output

--- a/marimba/core/installer/pipeline_installer.py
+++ b/marimba/core/installer/pipeline_installer.py
@@ -155,7 +155,7 @@ class PipelineInstaller:
             result = self._install_with_constraints(str(abs_path.parent))
         else:
             error_msg = f"Pipeline does not defines dependencies: {self.requirements_path} / {self.py_project_path}"
-            self._logger.exception(error_msg)
+            self._logger.error(error_msg)
             raise PipelineInstaller.InstallError(error_msg)
 
         if result.output:

--- a/marimba/core/pipeline.py
+++ b/marimba/core/pipeline.py
@@ -129,7 +129,7 @@ class BasePipeline(ABC, LogMixin):
 
         # Check for the existence of the source_path directory
         if not source_path.is_dir():
-            self.logger.exception(f"Source path {source_path} is not a directory")
+            self.logger.error(f"Source path {source_path} is not a directory")
             return
 
         self._import(data_dir, source_path, config, **kwargs)

--- a/marimba/core/utils/paths.py
+++ b/marimba/core/utils/paths.py
@@ -116,7 +116,7 @@ def hardlink_path(src_path: Path, dest_path: Path, dry_run: bool) -> None:
     """
     # Ensure the source path is valid and is a directory
     if not src_path.exists() or not src_path.is_dir():
-        logger.exception(f"Source path '{src_path}' is not a valid directory")
+        logger.error(f"Source path '{src_path}' is not a valid directory")
         raise typer.Exit(1)
 
     # Ensure the destination directory exists

--- a/marimba/core/wrappers/project.py
+++ b/marimba/core/wrappers/project.py
@@ -297,8 +297,10 @@ def execute_packaging(
 
     return (
         pipeline_data_mapping,
-        f'Completed packaging data for pipeline "{pipeline_name}" and collection "{collection_name}" in '
-        f"{package_duration:.2f} seconds",
+        (
+            f'Completed packaging data for pipeline "{pipeline_name}" and collection "{collection_name}" in '
+            f"{package_duration:.2f} seconds"
+        ),
     )
 
 
@@ -1491,7 +1493,7 @@ class ProjectWrapper(LogMixin):
 
         # Check if distribution_target is not None
         if distribution_target is None:
-            self.logger.exception("Failed to get a valid distribution target instance")
+            self.logger.error("Failed to get a valid distribution target instance")
             return
 
         # Distribute the dataset

--- a/marimba/main.py
+++ b/marimba/main.py
@@ -233,7 +233,7 @@ def import_command(
             raise typer.Exit(1) from None
     elif not overwrite:
         error_message = f"Collection {collection_name} already exists, and the overwrite flag is not set."
-        project_wrapper.logger.exception(error_message)
+        project_wrapper.logger.error(error_message)
         rprint(error_panel(error_message))
         raise typer.Exit(1) from None
 


### PR DESCRIPTION
## Why

Dependabot PR #95 bumps ruff from 0.15.22 to 0.16.0 as part of the dev-dependencies group, and its Code Quality job fails. The cause is not the dependency itself: `config/ruff.toml` uses `lint.select = ["ALL"]`, so rules that 0.16.0 promotes to stable start firing immediately. Against `marimba/` that is 54 CPY001, 26 PLR0917, 5 LOG004 and 1 ISC004, plus a further 71 CPY001 in `tests/`.

This PR makes the codebase clean under 0.16.0 so #95 can be rebased and merged on its own merits.

## What

**Rules ignored, with rationale recorded in the config:**

- `CPY001` (missing copyright notice at top of file). None of the 125 source files carry a per-file header; licensing is declared once in `LICENSE` and `pyproject.toml`. Adopting per-file headers would be a separate, deliberate decision rather than a side effect of a linter upgrade.
- `PLR0917` (too many positional arguments). This is the positional-only counterpart of `PLR0913`, which is already ignored, so ignoring it keeps the two consistent.

**Genuine findings fixed:**

- `LOG004`, 5 sites. `marimba/core/installer/pipeline_installer.py`, `marimba/core/pipeline.py`, `marimba/core/utils/paths.py`, `marimba/core/wrappers/project.py` and `marimba/main.py` each called `logger.exception(...)` from a branch with no exception in flight, which writes a misleading `NoneType: None` traceback into the audit trail. All five now use `logger.error(...)`, which also matches the documented convention that `exception()` is reserved for caught exceptions.
- `ISC004`, 1 site. The implicit f-string concatenation in the tuple returned by `execute_packaging()` is now parenthesised so it cannot be misread as a missing comma.

No behaviour changes beyond the log-level corrections.

## Verification

Checked against both linter versions, since this needs to land before the upgrade:

- ruff 0.16.0: ruff, black, mypy and bandit all clean over `marimba/` and `tests/`.
- ruff 0.15.22 (current lock): same suite clean, confirming the config is valid ahead of the bump.
- 1135 unit and integration tests pass, and the 45 e2e tests including the regression harness pass.

## Follow-up

Once this is merged, #95 needs a rebase to pick it up, after which its Code Quality job should go green.