### PR TITLE
Allow --config to load a YAML or JSON file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - `--config` accepts a path to a YAML or JSON file, as well as an inline JSON object string, on `marimba import`,
   `marimba new pipeline`, and `marimba new collection`. File contents are loaded with `yaml.safe_load`; Python is not
-  executed.
+  executed. Nested inline JSON is parsed as JSON rather than as a filesystem path, so values longer than ``NAME_MAX``
+  do not raise ``OSError: File name too long``.
 
 ## [1.2.0] – 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to Marimba are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- `--config` accepts a path to a YAML or JSON file, as well as an inline JSON object string, on `marimba import`,
+  `marimba new pipeline`, and `marimba new collection`. File contents are loaded with `yaml.safe_load`; Python is not
+  executed.
+
 ## [1.2.0] – 2026-06-25
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,8 +28,9 @@ option reference. For the full list of commands and options, see the
 By default `marimba new pipeline`, `marimba new collection` and `marimba import` prompt for pipeline- and
 collection-level configuration. Scripts must suppress those prompts, using one or both of:
 
-- **`--config '{"key": "value"}'`**: supply configuration values as a JSON string. They are merged with the pipeline's
-  schema defaults.
+- **`--config path/to/config.yml`**: supply configuration from a YAML or JSON file, or as an inline JSON object
+  string. File contents are loaded with `yaml.safe_load` (JSON is valid YAML). They are merged with the pipeline's
+  schema defaults. The file is not executed as Python.
 - **`--accept-defaults` (`-y`)**: accept every remaining default without prompting.
 
 Supply `--config` for the values you care about and add `--accept-defaults` to accept the rest, so no prompt can block
@@ -37,22 +38,15 @@ the script:
 
 ```bash
 marimba import dive-001 /data/raw/dive-001 \
-  --config '{"site_id": "GBR-001"}' \
+  --config collection.yml \
   --accept-defaults
 ```
 
-For configuration that is awkward to inline, build the JSON in a file and pass its contents:
+Inline JSON still works:
 
 ```bash
-cat > /tmp/collection-config.json <<'EOF'
-{
-  "site_id": "GBR-001",
-  "deployment_date": "2026-02-14"
-}
-EOF
-
 marimba import dive-001 /data/raw/dive-001 \
-  --config "$(cat /tmp/collection-config.json)" \
+  --config '{"site_id": "GBR-001"}' \
   --accept-defaults
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -223,7 +223,7 @@ pipeline-level configuration the pipeline declares.
 
 | Option | Description |
 | --- | --- |
-| `--config TEXT` | Custom configuration as a JSON string, merged with the prompted configuration. |
+| `--config TEXT` | YAML/JSON config file path, or a JSON object string, merged with the prompted configuration. |
 | `--accept-defaults`, `-y` | Accept all default configuration values without prompting. |
 | `--project-dir PATH` | Project root to operate on. |
 
@@ -239,7 +239,7 @@ collection inherit configuration; if omitted, the most recently modified collect
 
 | Option | Description |
 | --- | --- |
-| `--config TEXT` | Custom configuration as a JSON string, merged with the prompted configuration. |
+| `--config TEXT` | YAML/JSON config file path, or a JSON object string, merged with the prompted configuration. |
 | `--accept-defaults`, `-y` | Accept all default configuration values without prompting. |
 | `--project-dir PATH` | Project root to operate on. |
 
@@ -283,7 +283,7 @@ Each installed pipeline's `_import` logic decides how the source data is brought
 | `--pipeline-name TEXT` | Limit the import to specific pipelines (repeatable). Defaults to all pipelines. |
 | `--operation [copy\|move\|link]` | How source files are brought in. Default: `copy`. |
 | `--overwrite` / `--no-overwrite` | Overwrite an existing collection of the same name. Default: `--no-overwrite`. |
-| `--config TEXT` | Custom collection configuration as a JSON string. |
+| `--config TEXT` | YAML/JSON config file path, or a JSON object string. |
 | `--accept-defaults`, `-y` | Accept all default configuration values without prompting. |
 | `--extra TEXT` | Extra key-value pass-through argument (repeatable). |
 | `--dry-run` / `--no-dry-run` | Preview without changing files. Default: `--no-dry-run`. |
@@ -461,8 +461,9 @@ deployment or site identifier, or a collection date. You are prompted for it whe
 
 Both `--config` and `--accept-defaults` let you avoid interactive prompts, which is essential for scripting:
 
-- `--config '{"key": "value"}'` supplies configuration values directly as JSON; they are merged with the schema
-  defaults, and any remaining unset fields are still prompted for unless you also pass `--accept-defaults`.
+- `--config collection.yml` supplies configuration from a YAML or JSON file (or an inline JSON object string); values
+  are merged with the schema defaults, and any remaining unset fields are still prompted for unless you also pass
+  `--accept-defaults`.
 - `--accept-defaults` (`-y`) accepts every default value without prompting.
 
 See the [CLI Scripting Guide](cli.md) for non-interactive automation patterns.

--- a/marimba/core/cli/new.py
+++ b/marimba/core/cli/new.py
@@ -7,12 +7,12 @@ formatting the output.
 
 """
 
-import json
 from pathlib import Path
 
 import typer
 from rich import print as rprint
 
+from marimba.core.utils.config import parse_cli_config
 from marimba.core.utils.constants import PROJECT_DIR_HELP
 from marimba.core.utils.log import get_logger
 from marimba.core.utils.paths import find_project_dir_or_exit
@@ -73,7 +73,7 @@ def pipeline(
     ),
     config: str = typer.Option(
         None,
-        help="A custom configuration in JSON format to be merged with the prompted pipeline configuration.",
+        help="YAML/JSON config file path, or a JSON object string, merged with the prompted pipeline configuration.",
     ),
     accept_defaults: bool = typer.Option(
         False,
@@ -86,9 +86,9 @@ def pipeline(
     Create and configure a new Marimba pipeline in a project.
     """
     try:
-        config_dict = json.loads(config) if config else {}
-    except json.JSONDecodeError as e:
-        error_message = f"Error parsing configuration JSON: {e}"
+        config_dict = parse_cli_config(config)
+    except (ValueError, TypeError) as e:
+        error_message = f"Error parsing configuration: {e}"
         logger.exception(error_message)
         rprint(error_panel(error_message))
         raise typer.Exit(1) from e
@@ -146,7 +146,7 @@ def collection(
     project_dir: Path = typer.Option(None, help=PROJECT_DIR_HELP),
     config: str = typer.Option(
         None,
-        help="A custom configuration in JSON format to be merged with the prompted collection configuration.",
+        help="YAML/JSON config file path, or a JSON object string, merged with the prompted collection configuration.",
     ),
     accept_defaults: bool = typer.Option(
         False,
@@ -159,9 +159,9 @@ def collection(
     Create and configure a new Marimba collection in a project.
     """
     try:
-        config_dict = json.loads(config) if config else {}
-    except json.JSONDecodeError as e:
-        error_message = f"Error parsing configuration JSON: {e}"
+        config_dict = parse_cli_config(config)
+    except (ValueError, TypeError) as e:
+        error_message = f"Error parsing configuration: {e}"
         logger.exception(error_message)
         rprint(error_panel(error_message))
         raise typer.Exit(1) from e

--- a/marimba/core/utils/config.py
+++ b/marimba/core/utils/config.py
@@ -54,6 +54,34 @@ def save_config(config_path: str | Path, config_data: dict[Any, Any]) -> None:
         yaml.safe_dump(config_data, f)
 
 
+def _is_existing_config_file(config: str) -> bool:
+    """Return True if ``config`` names an existing file.
+
+    ``Path.is_file()`` raises ``OSError`` (e.g. ``ENAMETOOLONG``) for long inline
+    JSON on some Python/platform combinations instead of returning False.
+    """
+    try:
+        return Path(config).is_file()
+    except OSError:
+        return False
+
+
+def _parse_inline_json_object(config: str) -> dict[str, Any]:
+    """Parse an inline JSON object string."""
+    try:
+        data = json.loads(config)
+    except json.JSONDecodeError as exc:
+        msg = (
+            "Could not parse --config as JSON, and it is not an existing file. "
+            "Pass a YAML/JSON file path or a JSON object string."
+        )
+        raise ValueError(msg) from exc
+    if not isinstance(data, dict):
+        msg = "Configuration data must be a dictionary"
+        raise TypeError(msg)
+    return data
+
+
 def parse_cli_config(config: str | None) -> dict[str, Any]:
     """
     Parse a ``--config`` value as a YAML/JSON file path, or an inline JSON object.
@@ -74,22 +102,17 @@ def parse_cli_config(config: str | None) -> dict[str, Any]:
     """
     if not config:
         return {}
+    # Inline JSON objects/arrays must not be passed to Path.is_file(): a typical
+    # nested object is longer than NAME_MAX (255), and that raises OSError on
+    # Python 3.12/3.13 instead of returning False.
+    stripped = config.lstrip()
+    if stripped.startswith(("{", "[")):
+        return _parse_inline_json_object(config)
     path = Path(config)
-    if path.is_file():
+    if _is_existing_config_file(config):
         try:
             return load_config(path)
         except yaml.YAMLError as exc:
             msg = f"Invalid YAML/JSON in config file {path}: {exc}"
             raise ValueError(msg) from exc
-    try:
-        data = json.loads(config)
-    except json.JSONDecodeError as exc:
-        msg = (
-            "Could not parse --config as JSON, and it is not an existing file. "
-            "Pass a YAML/JSON file path or a JSON object string."
-        )
-        raise ValueError(msg) from exc
-    if not isinstance(data, dict):
-        msg = "Configuration data must be a dictionary"
-        raise TypeError(msg)
-    return data
+    return _parse_inline_json_object(config)

--- a/marimba/core/utils/config.py
+++ b/marimba/core/utils/config.py
@@ -6,6 +6,7 @@ file paths and converting YAML data to Python dictionaries.
 
 """
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -51,3 +52,44 @@ def save_config(config_path: str | Path, config_data: dict[Any, Any]) -> None:
 
     with config_path.open("w", encoding="utf-8") as f:
         yaml.safe_dump(config_data, f)
+
+
+def parse_cli_config(config: str | None) -> dict[str, Any]:
+    """
+    Parse a ``--config`` value as a YAML/JSON file path, or an inline JSON object.
+
+    Existing files are loaded with ``yaml.safe_load`` (JSON is valid YAML). Inline
+    strings still use ``json.loads``. Python is not executed.
+
+    Args:
+        config: A filesystem path, an inline JSON object string, or None/empty.
+
+    Returns:
+        The configuration dictionary. Empty input yields ``{}``.
+
+    Raises:
+        ValueError: If the value is not an existing file and not valid JSON, or if a
+            file exists but is not valid YAML/JSON.
+        TypeError: If parsed data is not a dictionary.
+    """
+    if not config:
+        return {}
+    path = Path(config)
+    if path.is_file():
+        try:
+            return load_config(path)
+        except yaml.YAMLError as exc:
+            msg = f"Invalid YAML/JSON in config file {path}: {exc}"
+            raise ValueError(msg) from exc
+    try:
+        data = json.loads(config)
+    except json.JSONDecodeError as exc:
+        msg = (
+            "Could not parse --config as JSON, and it is not an existing file. "
+            "Pass a YAML/JSON file path or a JSON object string."
+        )
+        raise ValueError(msg) from exc
+    if not isinstance(data, dict):
+        msg = "Configuration data must be a dictionary"
+        raise TypeError(msg)
+    return data

--- a/marimba/main.py
+++ b/marimba/main.py
@@ -32,7 +32,6 @@ Functions:
 """
 
 import importlib.metadata
-import json
 import logging
 import time
 from pathlib import Path
@@ -44,6 +43,7 @@ from rich.panel import Panel
 from marimba.core import MarimbaError, NetworkConnectionError
 from marimba.core.cli import delete, new
 from marimba.core.distribution.base import DistributionTargetBase
+from marimba.core.utils.config import parse_cli_config
 from marimba.core.utils.constants import PROJECT_DIR_HELP, MetadataGenerationLevelOptions, Operation
 from marimba.core.utils.dataset import get_mapping_processor_decorator
 from marimba.core.utils.dependencies import ToolDependency, validate_dependencies
@@ -180,7 +180,7 @@ def import_command(
     ),
     config: str = typer.Option(
         None,
-        help="A custom configuration in JSON format to be merged with the prompted collection configuration.",
+        help="YAML/JSON config file path, or a JSON object string, merged with the prompted collection configuration.",
     ),
     accept_defaults: bool = typer.Option(
         False,
@@ -209,9 +209,9 @@ def import_command(
     get_rich_handler().set_dry_run(dry_run)
 
     try:
-        config_dict = json.loads(config) if config else {}
-    except json.JSONDecodeError as e:
-        error_message = f"Error parsing configuration JSON: {e}"
+        config_dict = parse_cli_config(config)
+    except (ValueError, TypeError) as e:
+        error_message = f"Error parsing configuration: {e}"
         project_wrapper.logger.exception(error_message)
         rprint(error_panel(error_message))
         raise typer.Exit(1) from None

--- a/tests/core/cli/test_new.py
+++ b/tests/core/cli/test_new.py
@@ -472,6 +472,53 @@ class TestPipelineCommand:
         assert (project_dir / "pipelines").exists(), "Pipelines directory should still exist"
 
     @pytest.mark.integration
+    def test_pipeline_with_yaml_config_file(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """
+        Test pipeline command loads --config from a YAML file path.
+
+        Verifies that a filesystem path is treated as YAML rather than inline JSON,
+        and the parsed dictionary is passed to create_pipeline.
+        """
+        project_dir = tmp_path / "yaml_config_project"
+        pipeline_name = "test_yaml_pipeline"
+        url = "https://example.com/repo.git"
+        config_path = tmp_path / "pipeline.yml"
+        config_path.write_text("platform_id: CAM01\n", encoding="utf-8")
+
+        ProjectWrapper.create(project_dir)
+
+        mock_pipeline_wrapper = mocker.MagicMock()
+        mock_pipeline_wrapper.root_dir = project_dir / "pipelines" / pipeline_name
+        mock_create_pipeline = mocker.patch(
+            "marimba.core.wrappers.project.ProjectWrapper.create_pipeline",
+            return_value=mock_pipeline_wrapper,
+        )
+
+        result = runner.invoke(
+            marimba_cli,
+            [
+                "new",
+                "pipeline",
+                pipeline_name,
+                url,
+                "--project-dir",
+                str(project_dir),
+                "--config",
+                str(config_path),
+            ],
+        )
+
+        assert (
+            result.exit_code == 0
+        ), f"Command should succeed with exit code 0, got {result.exit_code} with output: {result.output}"
+        mock_create_pipeline.assert_called_once_with(
+            pipeline_name,
+            url,
+            {"platform_id": "CAM01"},
+            accept_defaults=False,
+        )
+
+    @pytest.mark.integration
     def test_pipeline_with_accept_defaults_flag(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """
         Test pipeline command with --accept-defaults flag passes accept_defaults=True to create_pipeline.

--- a/tests/core/utils/test_config.py
+++ b/tests/core/utils/test_config.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -304,6 +305,23 @@ class TestParseCliConfig:
         """Inline JSON object strings continue to parse as dictionaries."""
         loaded = parse_cli_config('{"site_id": "GBR-001", "count": 2}')
         assert loaded == {"site_id": "GBR-001", "count": 2}
+
+    @pytest.mark.unit
+    def test_parse_cli_config_long_inline_json_does_not_use_pathlib(self) -> None:
+        """Nested JSON longer than NAME_MAX must parse; Path.is_file() would OSError."""
+        payload = {
+            "name": "test_collection",
+            "site_id": "COMPLEX_SITE_01",
+            "field_of_view": "2000",
+            "instrument_type": "flowcam",
+            "operation": "copy",
+            "created": "2024-01-01T00:00:00Z",
+            "depth_range": {"min": 5.0, "max": 25.0},
+            "metadata": {"operator": "test_user", "mission": "test_mission_2024"},
+        }
+        config_json = json.dumps(payload)
+        assert len(config_json) > 255
+        assert parse_cli_config(config_json) == payload
 
     @pytest.mark.unit
     def test_parse_cli_config_inline_json_non_dict_raises_type_error(self) -> None:

--- a/tests/core/utils/test_config.py
+++ b/tests/core/utils/test_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from marimba.core.utils.config import load_config, save_config
+from marimba.core.utils.config import load_config, parse_cli_config, save_config
 
 
 class TestSaveConfig:
@@ -283,3 +283,65 @@ class TestLoadConfig:
         assert (
             loaded_data["database"]["credentials"]["user"] == "admin"
         ), f"User should be 'admin', got {loaded_data['database']['credentials']['user']}"
+
+
+class TestParseCliConfig:
+    """
+    Test suite for parse_cli_config.
+
+    Covers empty input, inline JSON, YAML/JSON files, and error paths. Files are
+    never executed as Python.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_parse_cli_config_empty_returns_empty_dict(self, value: str | None) -> None:
+        """Empty or missing --config values yield an empty dictionary."""
+        assert parse_cli_config(value) == {}
+
+    @pytest.mark.unit
+    def test_parse_cli_config_inline_json_object(self) -> None:
+        """Inline JSON object strings continue to parse as dictionaries."""
+        loaded = parse_cli_config('{"site_id": "GBR-001", "count": 2}')
+        assert loaded == {"site_id": "GBR-001", "count": 2}
+
+    @pytest.mark.unit
+    def test_parse_cli_config_inline_json_non_dict_raises_type_error(self) -> None:
+        """Inline JSON that is not an object is rejected."""
+        with pytest.raises(TypeError, match=r"Configuration data must be a dictionary"):
+            parse_cli_config('["not", "an", "object"]')
+
+    @pytest.mark.unit
+    def test_parse_cli_config_yaml_file(self, tmp_path: Path) -> None:
+        """An existing YAML file is loaded with yaml.safe_load."""
+        config_path = tmp_path / "collection.yml"
+        expected = {"site_id": "GBR-001", "timedif": "+08"}
+        with config_path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(expected, handle)
+
+        loaded = parse_cli_config(str(config_path))
+        assert loaded == expected
+
+    @pytest.mark.unit
+    def test_parse_cli_config_json_file(self, tmp_path: Path) -> None:
+        """JSON files are accepted because JSON is valid YAML."""
+        config_path = tmp_path / "collection.json"
+        config_path.write_text('{"site_id": "GBR-001"}\n', encoding="utf-8")
+
+        loaded = parse_cli_config(str(config_path))
+        assert loaded == {"site_id": "GBR-001"}
+
+    @pytest.mark.unit
+    def test_parse_cli_config_missing_path_that_is_not_json_raises_value_error(self) -> None:
+        """A non-existent path that is not JSON is a ValueError, not a file read."""
+        with pytest.raises(ValueError, match=r"Could not parse --config as JSON"):
+            parse_cli_config("does-not-exist.yml")
+
+    @pytest.mark.unit
+    def test_parse_cli_config_invalid_yaml_file_raises_value_error(self, tmp_path: Path) -> None:
+        """Malformed YAML in an existing file is wrapped as ValueError."""
+        config_path = tmp_path / "broken.yml"
+        config_path.write_text("key: value\ninvalid", encoding="utf-8")
+
+        with pytest.raises(ValueError, match=r"Invalid YAML/JSON in config file"):
+            parse_cli_config(str(config_path))


### PR DESCRIPTION
## Summary

`--config` on `import`, `new pipeline`, and `new collection` now accepts a path to a YAML or JSON file in addition to an inline JSON object string. File contents are loaded with `yaml.safe_load` (JSON is valid YAML). Python is not executed.

## Problem

Collection and pipeline configuration that is awkward to quote as inline JSON had to be stuffed into the shell. That is brittle on HPC and encourages copying values into shell history.

## Solution

Add `parse_cli_config()`: if the value is an existing file, load it as YAML/JSON; otherwise parse it as inline JSON as before. Empty input still yields `{}`.

## Impact

Existing inline-JSON scripts keep working. You can pass `--config collection.yml`. No schema change.

## Testing

Unit tests for empty input, inline JSON, YAML/JSON files, missing paths, and malformed YAML. CLI test that `marimba new pipeline --config path.yml` passes the parsed dict through. 22 passed. Ruff/black clean on the touched files.

## Documentation

CHANGELOG Unreleased, `docs/cli.md`, `docs/overview.md`.

## Breaking Changes

None. Inline JSON remains supported.

## Notes to Reviewer

If `--config` names a path that exists, it is always treated as a file, even if the string also happens to be valid JSON.
